### PR TITLE
BUILD-9545 Fix: Remove typo 'I' in jitter calculation

### DIFF
--- a/scripts/get-github-token.sh
+++ b/scripts/get-github-token.sh
@@ -69,7 +69,7 @@ get_github_token() {
     # Exponential backoff with jitter
     if [[ $attempt -lt $MAX_ATTEMPTS ]]; then
       local base_wait=$((2 ** attempt))
-      local jitter=$((RANDOM % 3))I
+      local jitter=$((RANDOM % 3))
       local wait_time=$((base_wait + jitter))
       log_warning "Retrying in ${wait_time}s..."
       sleep "$wait_time"


### PR DESCRIPTION
The jitter calculation had a hardcoded 'I' character that caused bash arithmetic errors:
  local jitter=$((RANDOM % 3))I

This resulted in values like '1I' or '2I' which are invalid for arithmetic operations.

Fixed by removing the 'I':
  local jitter=$((RANDOM % 3))

This bug prevented proper retry logic and error reporting when OIDC token requests failed.