### PR TITLE
BUILD-9956 import code from ci-github-actions/cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,54 @@
-# S3 Cache Action
+# `gh-action_cache`
+
+Adaptive cache action that automatically chooses the appropriate caching backend based on repository visibility and ownership.
+
+- Automatically uses GitHub Actions cache for public repositories
+- Uses SonarSource S3 cache for private/internal SonarSource repositories
+- Seamless API compatibility with standard GitHub Actions cache
+- Supports all standard cache inputs and outputs
+- Automatic repository visibility detection
+
+## Requirements
+
+- `jq`
+
+## Usage
+
+```yaml
+- uses: SonarSource/gh-action_cache@v1
+  with:
+    path: |
+      ~/.cache/pip
+      ~/.cache/maven
+    key: cache-${{ runner.os }}-${{ hashFiles('**/requirements.txt', '**/pom.xml') }}
+    restore-keys: cache-${{ runner.os }}-
+```
+
+## Inputs
+
+| Input                  | Description                                                                                                                     | Required | Default |
+|------------------------|---------------------------------------------------------------------------------------------------------------------------------|----------|---------|
+| `path`                 | Files, directories, and wildcard patterns to cache                                                                              | Yes      |         |
+| `key`                  | Explicit key for restoring and saving cache                                                                                     | Yes      |         |
+| `restore-keys`         | Ordered list of prefix-matched keys for fallback                                                                                | No       |         |
+| `fallback-branch`      | Optional maintenance branch for fallback restore keys (pattern: `branch-*`). If not set, the repository default branch is used. | No       |         |
+| `environment`          | Environment to use (dev or prod, S3 cache only)                                                                                 | No       | `prod`  |
+| `upload-chunk-size`    | Chunk size for large file uploads (bytes)                                                                                       | No       |         |
+| `enableCrossOsArchive` | Enable cross-OS cache compatibility                                                                                             | No       | `false` |
+| `fail-on-cache-miss`   | Fail workflow if cache entry not found                                                                                          | No       | `false` |
+| `lookup-only`          | Only check cache existence without downloading                                                                                  | No       | `false` |
+
+## Outputs
+
+| Output      | Description                                    |
+|-------------|------------------------------------------------|
+| `cache-hit` | Boolean indicating exact match for primary key |
+
+## S3 Cache Action
 
 A GitHub Action that provides branch-specific caching on AWS S3 with intelligent fallback to default branch cache entries.
 
-## Features
+### Features
 
 - **Branch-specific caching**: Cache entries are prefixed with `GITHUB_HEAD_REF` for granular permissions
 - **Intelligent fallback**: Feature branches can fall back to default branch cache when no branch-specific cache exists
@@ -10,28 +56,12 @@ A GitHub Action that provides branch-specific caching on AWS S3 with intelligent
 - **AWS Cognito authentication**: Secure authentication using GitHub Actions OIDC tokens
 - **Compatible with actions/cache**: Drop-in replacement with same interface
 
-## Usage
-
-Recommended usage is to use with the
-[`SonarSource/ci-github-actions/cache`](https://github.com/SonarSource/ci-github-actions?tab=readme-ov-file#cache) wrapper.
-
-```yaml
-- uses: SonarSource/ci-github-actions/cache@master
-  with:
-    path: |
-      ~/.npm
-      ~/.cache
-    key: node-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-    restore-keys: |
-      node-${{ runner.os }}
-```
-
-## How Restore Keys Work
+### How Restore Keys Work
 
 **Important**: This action's restore key behavior differs from the standard GitHub cache action.
 To enable fallback to default branch caches, you **must** use the `restore-keys` property.
 
-### Cache Key Resolution Order
+#### Cache Key Resolution Order
 
 When you provide `restore-keys`, the action searches for cache entries in this order:
 
@@ -41,15 +71,14 @@ When you provide `restore-keys`, the action searches for cache entries in this o
     - `refs/heads/${DEFAULT_BRANCH}/${restore-key}` (for each restore key, where `DEFAULT_BRANCH` is dynamically obtained from the
       repository)
 
-### Example
+#### Example
 
 ```yaml
-- uses: SonarSource/ci-github-actions/cache@master
+- uses: SonarSource/gh-action_cache@v1
   with:
     path: ~/.npm
     key: node-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-    restore-keys: |
-      node-${{ runner.os }}
+    restore-keys: node-${{ runner.os }}-
 ```
 
 For a feature branch `feature/new-ui`, this will search for:
@@ -58,33 +87,13 @@ For a feature branch `feature/new-ui`, this will search for:
 2. `feature/new-ui/node-linux` (branch-specific partial match)
 3. `refs/heads/main/node-linux` (default branch fallback, assuming `main` is the repository's default branch)
 
-### Key Differences from Standard Cache Action
+#### Key Differences from Standard Cache Action
 
 - **Fallback requires restore-keys**: Without `restore-keys`, the action only looks for branch-specific cache entries
 - **Dynamic default branch detection**: The action detects your default branch using the GitHub API and uses it for fallback
 - **Branch isolation**: Each branch maintains its own cache namespace, preventing cross-branch cache pollution
 
-## Inputs
-
-| Input                  | Description                                        | Required | Default |
-|------------------------|----------------------------------------------------|----------|---------|
-| `path`                 | Files, directories, and wildcard patterns to cache | Yes      |         |
-| `key`                  | Explicit key for restoring and saving cache        | Yes      |         |
-| `restore-keys`         | Ordered list of prefix-matched keys for fallback   | No       |         |
-| `fallback-branch`      | Optional maintenance branch for fallback restore keys (pattern: `branch-*`). If not set, the repository default branch is used. | No |         |
-| `environment`          | Environment to use (dev or prod)                   | No       | `prod`  |
-| `upload-chunk-size`    | Chunk size for large file uploads (bytes)          | No       |         |
-| `enableCrossOsArchive` | Enable cross-OS cache compatibility                | No       | `false` |
-| `fail-on-cache-miss`   | Fail workflow if cache entry not found             | No       | `false` |
-| `lookup-only`          | Only check cache existence without downloading     | No       | `false` |
-
-## Outputs
-
-| Output      | Description                                    |
-|-------------|------------------------------------------------|
-| `cache-hit` | Boolean indicating exact match for primary key |
-
-## Environment Configuration
+### Environment Configuration
 
 The action supports two environments:
 
@@ -93,8 +102,13 @@ The action supports two environments:
 
 Each environment has its own preconfigured S3 bucket and AWS Cognito pool for isolation and security.
 
-## Security
+### Security
 
 - Uses GitHub Actions OIDC tokens for secure authentication
 - No long-lived AWS credentials required
 - Branch-specific paths provide isolation between branches
+
+### Cleanup Policy
+
+The AWS S3 bucket lifecycle rules apply to delete the old files. The content from default branches expires in 60 days and for feature
+branches in 30 days.

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   upload-chunk-size:
     description: The chunk size used to split up large files during upload, in bytes
   enableCrossOsArchive:
-    description: An optional boolean when enabled, allows windows runners to save or restore caches that can be restored or saved respectively on other platforms
+    description: When enabled, allows to save or restore caches that can be restored or saved respectively on other platforms
     default: false
   fail-on-cache-miss:
     description: Fail the workflow if cache entry is not found
@@ -31,12 +31,53 @@ inputs:
 outputs:
   cache-hit:
     description: A boolean value to indicate an exact match was found for the primary key
-    value: ${{ steps.cache.outputs.cache-hit }}
+    value: ${{ steps.github-cache.outputs.cache-hit || steps.s3-cache.outputs.cache-hit }}
 
 runs:
   using: composite
   steps:
+    - name: Determine repository visibility
+      id: repo-visibility
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        REPO_VISIBILITY: ${{ github.event.repository.visibility }}
+      run: |
+        # If visibility is not available in the event, try to get it from the API
+        if [[ -z "$REPO_VISIBILITY" || "$REPO_VISIBILITY" = "null" ]]; then
+          REPO_VISIBILITY=$(curl -s -H "Authorization: token ${{ github.token }}" \
+            "https://api.github.com/repos/${{ github.repository }}" | \
+            jq -r '.visibility // "private"')
+        fi
+        echo "Repository visibility: $REPO_VISIBILITY"
+
+        if [[ "$REPO_VISIBILITY" == "public" ]]; then
+          CACHE_BACKEND="github"
+          echo "Using GitHub cache for public repository"
+        else
+          CACHE_BACKEND="s3"
+          echo "Using S3 cache for private/internal repository"
+        fi
+
+        echo "cache-backend=$CACHE_BACKEND" >> "$GITHUB_OUTPUT"
+        echo "repo-visibility=$REPO_VISIBILITY" >> "$GITHUB_OUTPUT"
+
+    - name: Cache with GitHub Actions (public repos)
+      if: steps.repo-visibility.outputs.cache-backend == 'github'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      id: github-cache
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.key }}
+        restore-keys: ${{ inputs.restore-keys }}
+        upload-chunk-size: ${{ inputs.upload-chunk-size }}
+        enableCrossOsArchive: ${{ inputs.enableCrossOsArchive }}
+        fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
+        lookup-only: ${{ inputs.lookup-only }}
+
+    # Cache with S3 (private/internal repos)
     - name: Authenticate to AWS
+      if: steps.repo-visibility.outputs.cache-backend == 's3'
       id: aws-auth
       shell: bash
       env:
@@ -72,31 +113,30 @@ runs:
         AWS_ACCESS_KEY_ID=$(echo "$awsCredentials" | jq -r ".Credentials.AccessKeyId")
         AWS_SECRET_ACCESS_KEY=$(echo "$awsCredentials" | jq -r ".Credentials.SecretKey")
         AWS_SESSION_TOKEN=$(echo "$awsCredentials" | jq -r ".Credentials.SessionToken")
-
-        echo "::add-mask::$AWS_ACCESS_KEY_ID"
-        echo "::add-mask::$AWS_SECRET_ACCESS_KEY"
-        echo "::add-mask::$AWS_SESSION_TOKEN"
-
         if [[ "$AWS_ACCESS_KEY_ID" == "null" || -z "$AWS_ACCESS_KEY_ID" ]]; then
           echo "::error::Failed to obtain AWS Access Key ID"
           exit 1
         fi
-
         if [[ "$AWS_SECRET_ACCESS_KEY" == "null" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
           echo "::error::Failed to obtain AWS Secret Access Key"
           exit 1
         fi
-
         if [[ "$AWS_SESSION_TOKEN" == "null" || -z "$AWS_SESSION_TOKEN" ]]; then
           echo "::error::Failed to obtain AWS Session Token"
           exit 1
         fi
+        echo "::add-mask::$AWS_ACCESS_KEY_ID"
+        echo "::add-mask::$AWS_SECRET_ACCESS_KEY"
+        echo "::add-mask::$AWS_SESSION_TOKEN"
 
-        echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> "$GITHUB_OUTPUT"
-        echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> "$GITHUB_OUTPUT"
-        echo "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" >> "$GITHUB_OUTPUT"
+        {
+          echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+          echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+          echo "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Prepare cache keys
+      if: steps.repo-visibility.outputs.cache-backend == 's3'
       shell: bash
       id: prepare-keys
       env:
@@ -105,11 +145,12 @@ runs:
         INPUT_FALLBACK_BRANCH: ${{ inputs.fallback-branch }}
         GITHUB_TOKEN: ${{ github.token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
-      run: "$GITHUB_ACTION_PATH/scripts/prepare-keys.sh"
+      run: $GITHUB_ACTION_PATH/scripts/prepare-keys.sh
 
     - name: Cache on S3
+      if: steps.repo-visibility.outputs.cache-backend == 's3'
       uses: runs-on/cache@50350ad4242587b6c8c2baa2e740b1bc11285ff4 # v4.3.0
-      id: cache
+      id: s3-cache
       env:
         RUNS_ON_S3_BUCKET_CACHE: sonarsource-s3-cache-${{ inputs.environment }}-bucket
         AWS_DEFAULT_REGION: eu-central-1

--- a/scripts/prepare-keys.sh
+++ b/scripts/prepare-keys.sh
@@ -22,9 +22,8 @@ BRANCH_KEY="${BRANCH_NAME}/${INPUT_KEY}"
 echo "branch-key=${BRANCH_KEY}" >> "$GITHUB_OUTPUT"
 
 # Process restore keys: keep branch-specific keys and add fallback to default branch
-if [ -n "${INPUT_RESTORE_KEYS:-}" ]; then
+if [[ -n "${INPUT_RESTORE_KEYS:-}" ]]; then
   RESTORE_KEYS=""
-
   # First, add branch-specific restore keys
   while IFS= read -r line; do
     if [ -n "$line" ]; then
@@ -52,7 +51,7 @@ if [ -n "${INPUT_RESTORE_KEYS:-}" ]; then
       main|master|branch-*)
         # Add fallback branch restore keys
         while IFS= read -r line; do
-          if [ -n "$line" ]; then
+          if [[ -n "$line" ]]; then
             RESTORE_KEYS="${RESTORE_KEYS}"$'\n'"refs/heads/${FALLBACK_BRANCH}/${line}"
           fi
         done <<< "$INPUT_RESTORE_KEYS"
@@ -65,7 +64,9 @@ if [ -n "${INPUT_RESTORE_KEYS:-}" ]; then
     echo "::warning::Unable to determine fallback branch; skipping fallback restore keys."
   fi
 
-  echo "branch-restore-keys<<EOF" >> "$GITHUB_OUTPUT"
-  echo "$RESTORE_KEYS" >> "$GITHUB_OUTPUT"
-  echo "EOF" >> "$GITHUB_OUTPUT"
+  {
+    echo "branch-restore-keys<<EOF"
+    echo "$RESTORE_KEYS"
+    echo "EOF"
+  } >> "$GITHUB_OUTPUT"
 fi


### PR DESCRIPTION
BUILD-9956 Import https://github.com/SonarSource/ci-github-actions/tree/master/cache

The action will now redirect to actions/cache for public repositories and runs-on/cache for private repositories.

Tested with:
- https://github.com/SonarSource/ci-github-actions/pull/189
- https://github.com/SonarSource/sonar-dummy-maven-enterprise/pull/113
    ```
    Post Run
    Cache hit occurred on the primary key test/jcarsique/BUILD-9956-cachePostRun/maven-Linux-Build-a0b8c8ba5d732f2420b8e0585b76c154a3e61507213c90eef28b9c760fbae12f, not saving cache.
    ```