### PR TITLE
BUILD-9956 fix post run aws auth

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -7,12 +7,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  test-github-cache:
     runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
       contents: read
-
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
@@ -22,12 +21,10 @@ jobs:
       id: cache-python
       uses: ./
       with:
-        path: |
-          ~/.cache/pip
+        path: ~/.cache/pip
         key: python-${{ runner.os }}-pytest-requests
         restore-keys: python-${{ runner.os }}-
-        environment: dev
-
+        backend: github
     - name: Check cache hit result
       run: |
         echo "Cache hit: ${{ steps.cache-python.outputs.cache-hit }}"
@@ -43,12 +40,46 @@ jobs:
     - name: Run tests
       run: python -m pytest --version
 
-  cache-with-fallback:
+  test-s3-cache:
     runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
       contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          version: 2025.7.12
+      - name: Cache Python dependencies
+        id: cache-python
+        uses: ./
+        with:
+          path: ~/.cache/pip
+          key: python-${{ runner.os }}-pytest-requests
+          restore-keys: python-${{ runner.os }}-
+          environment: dev
+          backend: s3
 
+      - name: Check cache hit result
+        run: |
+          echo "Cache hit: ${{ steps.cache-python.outputs.cache-hit }}"
+          if [ "${{ steps.cache-python.outputs.cache-hit }}" == "true" ]; then
+            echo "✅ Cache was found and restored"
+          else
+            echo "❌ Cache was not found, will need to rebuild"
+          fi
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest requests
+      - name: Run tests
+        run: python -m pytest --version
+
+  test-s3-cache-with-fallback:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
@@ -68,6 +99,7 @@ jobs:
         fail-on-cache-miss: false
         fallback-branch: refs/heads/branch-2
         environment: dev
+        backend: s3
     - name: Check Go cache hit result
       run: |
         echo "Go cache hit: ${{ steps.cache-go.outputs.cache-hit }}"

--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ Adaptive cache action that automatically chooses the appropriate caching backend
 
 ## Inputs
 
-| Input                  | Description                                                                                                                     | Required | Default |
-|------------------------|---------------------------------------------------------------------------------------------------------------------------------|----------|---------|
-| `path`                 | Files, directories, and wildcard patterns to cache                                                                              | Yes      |         |
-| `key`                  | Explicit key for restoring and saving cache                                                                                     | Yes      |         |
-| `restore-keys`         | Ordered list of prefix-matched keys for fallback                                                                                | No       |         |
-| `fallback-branch`      | Optional maintenance branch for fallback restore keys (pattern: `branch-*`). If not set, the repository default branch is used. | No       |         |
-| `environment`          | Environment to use (dev or prod, S3 cache only)                                                                                 | No       | `prod`  |
-| `upload-chunk-size`    | Chunk size for large file uploads (bytes)                                                                                       | No       |         |
-| `enableCrossOsArchive` | Enable cross-OS cache compatibility                                                                                             | No       | `false` |
-| `fail-on-cache-miss`   | Fail workflow if cache entry not found                                                                                          | No       | `false` |
-| `lookup-only`          | Only check cache existence without downloading                                                                                  | No       | `false` |
+| Input                  | Description                                                                                                                                      | Required | Default |
+|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------|
+| `path`                 | Files, directories, and wildcard patterns to cache                                                                                               | Yes      |         |
+| `key`                  | Explicit key for restoring and saving cache                                                                                                      | Yes      |         |
+| `restore-keys`         | Ordered list of prefix-matched keys for fallback                                                                                                 | No       |         |
+| `fallback-branch`      | Optional maintenance branch for fallback restore keys (pattern: `branch-*`, S3 backend only). If not set, the repository default branch is used. | No       |         |
+| `environment`          | Environment to use (dev or prod, S3 backend only)                                                                                                | No       | `prod`  |
+| `upload-chunk-size`    | Chunk size for large file uploads (bytes)                                                                                                        | No       |         |
+| `enableCrossOsArchive` | Enable cross-OS cache compatibility                                                                                                              | No       | `false` |
+| `fail-on-cache-miss`   | Fail workflow if cache entry not found                                                                                                           | No       | `false` |
+| `lookup-only`          | Only check cache existence without downloading                                                                                                   | No       | `false` |
+| `backend`              | Force specific backend: `github` or `s3`                                                                                                         | No       |         |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -23,10 +23,13 @@ inputs:
     description: Check if a cache entry exists for the given input(s) (key, restore-keys) without downloading the cache
     default: false
   environment:
-    description: Environment to use (dev or prod)
+    description: Environment to use ('dev' or 'prod', 's3' backend only).
     default: prod
   fallback-branch:
-    description: Optional maintenance branch for fallback restore keys (pattern branch-*). If not set, the repository default branch is used.
+    description: Optional maintenance branch for fallback restore keys (pattern 'branch-*', 's3' backend only). If not set, the repository
+      default branch is used.
+  backend:
+    description: Force cache backend ('github' or 's3'). If not set, automatically determined based on repository visibility.
 
 outputs:
   cache-hit:
@@ -36,34 +39,39 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Determine repository visibility
-      id: repo-visibility
+    - name: Determine cache backend
+      id: cache-backend
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
         REPO_VISIBILITY: ${{ github.event.repository.visibility }}
+        FORCED_BACKEND: ${{ inputs.backend }}
       run: |
-        # If visibility is not available in the event, try to get it from the API
-        if [[ -z "$REPO_VISIBILITY" || "$REPO_VISIBILITY" = "null" ]]; then
-          REPO_VISIBILITY=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            "https://api.github.com/repos/${{ github.repository }}" | \
-            jq -r '.visibility // "private"')
-        fi
-        echo "Repository visibility: $REPO_VISIBILITY"
-
-        if [[ "$REPO_VISIBILITY" == "public" ]]; then
-          CACHE_BACKEND="github"
-          echo "Using GitHub cache for public repository"
+        if [[ "$FORCED_BACKEND" == "github" || "$FORCED_BACKEND" == "s3" ]]; then
+          CACHE_BACKEND="$FORCED_BACKEND"
+          echo "Using forced backend: $CACHE_BACKEND"
         else
-          CACHE_BACKEND="s3"
-          echo "Using S3 cache for private/internal repository"
+          # If visibility is not available in the event, try to get it from the API
+          if [[ -z "$REPO_VISIBILITY" || "$REPO_VISIBILITY" = "null" ]]; then
+            REPO_VISIBILITY=$(curl -s -H "Authorization: token ${{ github.token }}" \
+              "https://api.github.com/repos/${{ github.repository }}" | \
+              jq -r '.visibility // "private"')
+          fi
+          echo "Repository visibility: $REPO_VISIBILITY"
+
+          if [[ "$REPO_VISIBILITY" == "public" ]]; then
+            CACHE_BACKEND="github"
+            echo "Using GitHub cache for public repository"
+          else
+            CACHE_BACKEND="s3"
+            echo "Using S3 cache for private/internal repository"
+          fi
         fi
 
         echo "cache-backend=$CACHE_BACKEND" >> "$GITHUB_OUTPUT"
-        echo "repo-visibility=$REPO_VISIBILITY" >> "$GITHUB_OUTPUT"
 
     - name: Cache with GitHub Actions (public repos)
-      if: steps.repo-visibility.outputs.cache-backend == 'github'
+      if: steps.cache-backend.outputs.cache-backend == 'github'
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: github-cache
       with:
@@ -77,7 +85,7 @@ runs:
 
     # Cache with S3 (private/internal repos)
     - name: Authenticate to AWS
-      if: steps.repo-visibility.outputs.cache-backend == 's3'
+      if: steps.cache-backend.outputs.cache-backend == 's3'
       id: aws-auth
       shell: bash
       env:
@@ -136,7 +144,7 @@ runs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Prepare cache keys
-      if: steps.repo-visibility.outputs.cache-backend == 's3'
+      if: steps.cache-backend.outputs.cache-backend == 's3'
       shell: bash
       id: prepare-keys
       env:
@@ -148,13 +156,14 @@ runs:
       run: $GITHUB_ACTION_PATH/scripts/prepare-keys.sh
 
     - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+      if: steps.cache-backend.outputs.cache-backend == 's3'
       with:
         aws-region: eu-central-1
         aws-access-key-id: ${{ steps.aws-auth.outputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ steps.aws-auth.outputs.AWS_SECRET_ACCESS_KEY }}
         aws-session-token: ${{ steps.aws-auth.outputs.AWS_SESSION_TOKEN }}
     - name: Cache on S3
-      if: steps.repo-visibility.outputs.cache-backend == 's3'
+      if: steps.cache-backend.outputs.cache-backend == 's3'
       uses: runs-on/cache@50350ad4242587b6c8c2baa2e740b1bc11285ff4 # v4.3.0
       id: s3-cache
       env:

--- a/action.yml
+++ b/action.yml
@@ -147,6 +147,12 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
       run: $GITHUB_ACTION_PATH/scripts/prepare-keys.sh
 
+    - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+      with:
+        aws-region: eu-central-1
+        aws-access-key-id: ${{ steps.aws-auth.outputs.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ steps.aws-auth.outputs.AWS_SECRET_ACCESS_KEY }}
+        aws-session-token: ${{ steps.aws-auth.outputs.AWS_SESSION_TOKEN }}
     - name: Cache on S3
       if: steps.repo-visibility.outputs.cache-backend == 's3'
       uses: runs-on/cache@50350ad4242587b6c8c2baa2e740b1bc11285ff4 # v4.3.0
@@ -155,9 +161,6 @@ runs:
         RUNS_ON_S3_BUCKET_CACHE: sonarsource-s3-cache-${{ inputs.environment }}-bucket
         AWS_DEFAULT_REGION: eu-central-1
         AWS_REGION: eu-central-1
-        AWS_ACCESS_KEY_ID: ${{ steps.aws-auth.outputs.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ steps.aws-auth.outputs.AWS_SECRET_ACCESS_KEY }}
-        AWS_SESSION_TOKEN: ${{ steps.aws-auth.outputs.AWS_SESSION_TOKEN }}
       with:
         path: ${{ inputs.path }}
         key: ${{ steps.prepare-keys.outputs.branch-key }}


### PR DESCRIPTION
BUILD-9956

Add `backend` input option to force the selection of the backend (`github` or `s3`) instead of the default selection based on the repository visibility.

Add tests to cover both `github` and `s3` backends.

Fix the AWS authentication.
- the aws-auth step must share the AWS credentials with runs-on/cache
- using global env is not possible as it pollutes the caller environment
- using step level env fails in the post run execution due to bugs in the AWS client used by runs-on/cache
The solution is to use aws-actions/configure-aws-credentials to locally save the credentials.
```
Cache saved successfully.
Cache saved with key: fix/jcarsique/BUILD-9956-awsPostRun/python-Linux-pytest-requests
```