### PR TITLE
PREQ-3880 AWS credentials refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Adaptive cache action that automatically chooses the appropriate caching backend
 
 ## Requirements
 
+- `aws` (AWS CLI)
 - `jq`
 
 ## Usage
@@ -111,12 +112,13 @@ Each environment has its own preconfigured S3 bucket and AWS Cognito pool for is
 
 ### AWS Credential Isolation
 
-This action creates a dedicated AWS profile (`gh-action-cache-<run_id>`) to store its credentials.
-This ensures that cache operations work correctly even when you configure your own AWS credentials later in the workflow.
+This action configures a dedicated AWS profile (`gh-action-cache`) backed by `credential_process`.
+Credentials are fetched on demand using GitHub OIDC + Cognito and never exported to `GITHUB_ENV`.
+This ensures cache operations work correctly even when you configure your own AWS credentials later in the workflow.
 
 **Why this matters**: The cache save operation happens in a GitHub Actions post-step (after your job completes).
 If you use `aws-actions/configure-aws-credentials` during your job, it would normally override the cache action's credentials,
-causing cache save to fail.
+causing cache save to fail. The cache profile stays isolated and is only used by the cache step.
 
 **Example workflow that works correctly**:
 
@@ -124,8 +126,8 @@ causing cache save to fail.
 jobs:
   build:
     steps:
-      # Cache action authenticates and stores credentials in isolated profile
-      - uses: SonarSource/gh-action-cache@v1
+      # Cache action authenticates and uses isolated profile
+      - uses: SonarSource/gh-action_cache@v1
         with:
           path: ~/.cache
           key: my-cache-${{ hashFiles('**/lockfile') }}

--- a/action.yml
+++ b/action.yml
@@ -84,9 +84,8 @@ runs:
         lookup-only: ${{ inputs.lookup-only }}
 
     # Cache with S3 (private/internal repos)
-    - name: Authenticate to AWS
+    - name: Configure cache credential profile
       if: steps.cache-backend.outputs.cache-backend == 's3'
-      id: aws-auth
       shell: bash
       env:
         POOL_ID: ${{ inputs.environment == 'prod' && 'eu-central-1:511fe374-ae4f-46d0-adb7-9246e570c7f4' || 'eu-central-1:3221c6ea-3f67-4fd8-a7ff-7426f96add89' }}
@@ -94,65 +93,16 @@ runs:
         IDENTITY_PROVIDER_NAME: token.actions.githubusercontent.com
         AUDIENCE: cognito-identity.amazonaws.com
         AWS_REGION: eu-central-1
-        GITHUB_RUN_ID: ${{ github.run_id }}
       run: |
-        # Get GitHub Actions ID token using script
-        ACCESS_TOKEN=$("$GITHUB_ACTION_PATH/scripts/get-github-token.sh")
-        echo "::add-mask::$ACCESS_TOKEN"
-
-        # Get Identity ID
-        identityId=$(aws cognito-identity get-id \
-        --identity-pool-id "$POOL_ID" \
-        --account-id "$AWS_ACCOUNT_ID" \
-        --logins '{"'"$IDENTITY_PROVIDER_NAME"'":"'"$ACCESS_TOKEN"'"}' \
-        --query 'IdentityId' --output text)
-
-        # Validate Identity ID was obtained
-        if [[ "$identityId" == "null" || -z "$identityId" ]]; then
-          echo "::error::Failed to obtain Identity ID from Cognito Identity Pool"
-          echo "::error::Check identity pool configuration and IAM roles"
-          exit 1
-        fi
-
-        # Get and validate AWS credentials
-        awsCredentials=$(aws cognito-identity get-credentials-for-identity \
-        --identity-id "$identityId" \
-        --logins '{"'"$IDENTITY_PROVIDER_NAME"'":"'"$ACCESS_TOKEN"'"}')
-
-        AWS_ACCESS_KEY_ID=$(echo "$awsCredentials" | jq -r ".Credentials.AccessKeyId")
-        AWS_SECRET_ACCESS_KEY=$(echo "$awsCredentials" | jq -r ".Credentials.SecretKey")
-        AWS_SESSION_TOKEN=$(echo "$awsCredentials" | jq -r ".Credentials.SessionToken")
-        if [[ "$AWS_ACCESS_KEY_ID" == "null" || -z "$AWS_ACCESS_KEY_ID" ]]; then
-          echo "::error::Failed to obtain AWS Access Key ID"
-          exit 1
-        fi
-        if [[ "$AWS_SECRET_ACCESS_KEY" == "null" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
-          echo "::error::Failed to obtain AWS Secret Access Key"
-          exit 1
-        fi
-        if [[ "$AWS_SESSION_TOKEN" == "null" || -z "$AWS_SESSION_TOKEN" ]]; then
-          echo "::error::Failed to obtain AWS Session Token"
-          exit 1
-        fi
-        echo "::add-mask::$AWS_ACCESS_KEY_ID"
-        echo "::add-mask::$AWS_SECRET_ACCESS_KEY"
-        echo "::add-mask::$AWS_SESSION_TOKEN"
-
-        # Create a unique AWS profile to isolate credentials from user-configured AWS credentials
-        # This prevents credential override when users call aws-actions/configure-aws-credentials
-        # between the cache restore (main step) and cache save (post step)
-        PROFILE_NAME="gh-action-cache-${GITHUB_RUN_ID}"
-
+        PROFILE_NAME="gh-action-cache"
         mkdir -p ~/.aws
         chmod 700 ~/.aws
 
-        # Write credentials to a dedicated profile using AWS CLI (handles file format and permissions correctly)
-        aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" --profile "$PROFILE_NAME"
-        aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" --profile "$PROFILE_NAME"
-        aws configure set aws_session_token "$AWS_SESSION_TOKEN" --profile "$PROFILE_NAME"
-        aws configure set region eu-central-1 --profile "$PROFILE_NAME"
-        echo "Created AWS profile: $PROFILE_NAME"
-        echo "AWS_PROFILE=$PROFILE_NAME" >> "$GITHUB_OUTPUT"
+        cat <<CONFIG >> ~/.aws/config
+        [profile ${PROFILE_NAME}]
+        region = ${AWS_REGION}
+        credential_process = ${GITHUB_ACTION_PATH}/scripts/cache-credential-process.sh
+        CONFIG
 
     - name: Prepare cache keys
       if: steps.cache-backend.outputs.cache-backend == 's3'
@@ -174,10 +124,13 @@ runs:
         RUNS_ON_S3_BUCKET_CACHE: sonarsource-s3-cache-${{ inputs.environment }}-bucket
         AWS_DEFAULT_REGION: eu-central-1
         AWS_REGION: eu-central-1
-        # Use AWS profile instead of direct credentials to prevent override issues
-        # When users configure their own AWS credentials mid-job, the profile remains isolated
-        AWS_PROFILE: ${{ steps.aws-auth.outputs.AWS_PROFILE }}
-        AWS_DEFAULT_PROFILE: ${{ steps.aws-auth.outputs.AWS_PROFILE }}
+        AWS_SDK_LOAD_CONFIG: 1
+        AWS_PROFILE: gh-action-cache
+        AWS_DEFAULT_PROFILE: gh-action-cache
+        POOL_ID: ${{ inputs.environment == 'prod' && 'eu-central-1:511fe374-ae4f-46d0-adb7-9246e570c7f4' || 'eu-central-1:3221c6ea-3f67-4fd8-a7ff-7426f96add89' }}
+        AWS_ACCOUNT_ID: ${{ inputs.environment == 'prod' && '275878209202' || '460386131003' }}
+        IDENTITY_PROVIDER_NAME: token.actions.githubusercontent.com
+        AUDIENCE: cognito-identity.amazonaws.com
       with:
         path: ${{ inputs.path }}
         key: ${{ steps.prepare-keys.outputs.branch-key }}

--- a/scripts/cache-credential-process.sh
+++ b/scripts/cache-credential-process.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+: "${POOL_ID:?}" "${AWS_ACCOUNT_ID:?}" "${IDENTITY_PROVIDER_NAME:?}" "${AUDIENCE:?}" "${AWS_REGION:?}"
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "::error title=AWS CLI is required for credential_process"
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error title=jq is required for credential_process"
+  exit 1
+fi
+
+ACCESS_TOKEN=$("$script_dir/get-github-token.sh")
+
+AWS_EC2_METADATA_DISABLED=true
+AWS_MAX_ATTEMPTS=3
+AWS_RETRY_MODE=standard
+
+identity_id=$(timeout 30s aws --no-sign-request cognito-identity get-id \
+  --identity-pool-id "$POOL_ID" \
+  --account-id "$AWS_ACCOUNT_ID" \
+  --logins "{\"${IDENTITY_PROVIDER_NAME}\":\"${ACCESS_TOKEN}\"}" \
+  --query 'IdentityId' --output text)
+
+if [[ "$identity_id" == "null" || -z "$identity_id" ]]; then
+  echo "::error title=Failed to obtain Identity ID from Cognito Identity Pool"
+  exit 1
+fi
+
+aws_credentials=$(timeout 30s aws --no-sign-request cognito-identity get-credentials-for-identity \
+  --identity-id "$identity_id" \
+  --logins "{\"${IDENTITY_PROVIDER_NAME}\":\"${ACCESS_TOKEN}\"}")
+
+access_key_id=$(echo "$aws_credentials" | jq -r ".Credentials.AccessKeyId")
+secret_access_key=$(echo "$aws_credentials" | jq -r ".Credentials.SecretKey")
+session_token=$(echo "$aws_credentials" | jq -r ".Credentials.SessionToken")
+expiration=$(echo "$aws_credentials" | jq -r ".Credentials.Expiration")
+
+if [[ "$access_key_id" == "null" || -z "$access_key_id" ]]; then
+  echo "::error title=Failed to obtain AWS Access Key ID"
+  exit 1
+fi
+if [[ "$secret_access_key" == "null" || -z "$secret_access_key" ]]; then
+  echo "::error title=Failed to obtain AWS Secret Access Key"
+  exit 1
+fi
+if [[ "$session_token" == "null" || -z "$session_token" ]]; then
+  echo "::error title=Failed to obtain AWS Session Token"
+  exit 1
+fi
+
+cat <<JSON
+{
+  "Version": 1,
+  "AccessKeyId": "${access_key_id}",
+  "SecretAccessKey": "${secret_access_key}",
+  "SessionToken": "${session_token}",
+  "Expiration": "${expiration}"
+}
+JSON


### PR DESCRIPTION
- Replaced static cache credentials with a credential_process-backed AWS profile to avoid leaking credentials into user steps.
- Added [cache-credential-process.sh](app://-/index.html#) to fetch short‑lived Cognito credentials on demand (OIDC → Cognito).
- Updated [action.yml](app://-/index.html#) to register the gh-action-cache profile in ~/.aws/config and scope AWS env vars to the cache step only.
- Ensured cache step uses AWS_SDK_LOAD_CONFIG=1 with AWS_PROFILE/AWS_DEFAULT_PROFILE=gh-action-cache so runs-on/cache post step can still authenticate.
- Hardened the credential process script with dependency checks and timeouts to prevent silent hangs.

Testing in runs 2 (create) and 3 (restore) in https://github.com/SonarSource/re-service-config/actions/runs/21628716053/job/62335779648