### PR TITLE
BUILD-10389 support CACHE_BACKEND env var for backend selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,7 @@ npm-debug.log*
 .DS_Store
 Thumbs.db
 
-# npm cache
-.npm
-
-# Claude Code
 .claude
+.idea
+.npm
+.serena

--- a/README.md
+++ b/README.md
@@ -72,7 +72,27 @@ Bundled output goes to `credential-setup/dist/` and `credential-guard/dist/`. Th
 | `enableCrossOsArchive` | Enable cross-OS cache compatibility                                                                                                              | No       | `false` |
 | `fail-on-cache-miss`   | Fail workflow if cache entry not found                                                                                                           | No       | `false` |
 | `lookup-only`          | Only check cache existence without downloading                                                                                                   | No       | `false` |
-| `backend`              | Force specific backend: `github` or `s3`                                                                                                         | No       |         |
+| `backend`              | Force specific backend: `github` or `s3`. Takes priority over `CACHE_BACKEND` env var and auto-detection.                                        | No       |         |
+
+## Backend Selection
+
+The cache backend is determined in the following priority order:
+
+1. **`inputs.backend`** — explicit input in the action step (`github` or `s3`)
+2. **`CACHE_BACKEND` environment variable** — set at the job or workflow level (`github` or `s3`)
+3. **Repository visibility** — `github` for public repos, `s3` for private/internal repos
+
+The `CACHE_BACKEND` env var is useful when the cache action is called indirectly through a composite action and you cannot set the `backend`
+input directly:
+
+```yaml
+jobs:
+  build:
+    env:
+      CACHE_BACKEND: s3   # forces S3 for all cache steps, including those in reusable actions
+    steps:
+      - uses: SonarSource/some-other-action@v1  # internally calls gh-action_cache
+```
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,9 @@ inputs:
     description: Optional maintenance branch for fallback restore keys (pattern 'branch-*', 's3' backend only). If not set, the repository
       default branch is used.
   backend:
-    description: Force cache backend ('github' or 's3'). If not set, automatically determined based on repository visibility.
+    description: >
+      Force cache backend ('github' or 's3'). If not set, falls back to the CACHE_BACKEND environment variable if defined,
+      then automatically determined based on repository visibility.
 
 outputs:
   cache-hit:
@@ -49,7 +51,9 @@ runs:
       run: |
         if [[ "$FORCED_BACKEND" == "github" || "$FORCED_BACKEND" == "s3" ]]; then
           CACHE_BACKEND="$FORCED_BACKEND"
-          echo "Using forced backend: $CACHE_BACKEND"
+          echo "Using forced backend from input: $CACHE_BACKEND"
+        elif [[ "$CACHE_BACKEND" == "github" || "$CACHE_BACKEND" == "s3" ]]; then
+          echo "Using backend from CACHE_BACKEND environment variable: $CACHE_BACKEND"
         else
           # If visibility is not available in the event, try to get it from the API
           if [[ -z "$REPO_VISIBILITY" || "$REPO_VISIBILITY" = "null" ]]; then


### PR DESCRIPTION
Add `CACHE_BACKEND` environment variable as a middle fallback in the backend selection logic, between the explicit `backend` input and the automatic repo-visibility detection.

Priority order: inputs.backend > CACHE_BACKEND env var > repo visibility

This allows callers of composite actions that internally use this cache action to override the backend without having access to the action inputs.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Tested with:
- https://github.com/SonarSource/gh-action_cache/pull/40
- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/336