### PR TITLE
BUILD-10761: Fix credential guard SQ Analysis security hotspot 

### DIFF
--- a/__tests__/credential-guard.test.ts
+++ b/__tests__/credential-guard.test.ts
@@ -23,14 +23,15 @@ describe('credential-guard-main', () => {
   });
 
   it('saves credentials file path to GITHUB_STATE', async () => {
-    vi.mocked(core.getInput).mockReturnValue('/tmp/creds/credentials.json');
+    const credsPath = path.join(os.tmpdir(), 'creds', 'credentials.json');
+    vi.mocked(core.getInput).mockReturnValue(credsPath);
 
     const { run } = await import('../src/credential-guard-main');
     await run();
 
     expect(core.saveState).toHaveBeenCalledWith(
       'credentials-file',
-      '/tmp/creds/credentials.json'
+      credsPath
     );
   });
 


### PR DESCRIPTION
## Problem
All recent ~5 recent commits on master have been failing the **SonarCloud Code Analysis** check due to Security Hotspots, see screenshot below and [link to hotspots](https://sonarcloud.io/summary/new_code?id=SonarSource_gh-action_cache&branch=master).

<img width="1383" height="463" alt="Screenshot 2026-03-19 at 2 12 55 PM" src="https://github.com/user-attachments/assets/545b732e-cf83-4bf2-b586-61724d0014c4" />
<img width="1313" height="919" alt="Screenshot 2026-03-19 at 2 13 45 PM" src="https://github.com/user-attachments/assets/b78f904d-7be9-4297-b353-9f16a1a412a0" />

## What Changed?
- This PR fixes the credential guard SQ Analysis security hotspot relating to tmp dir creds file for the credential guard check