### PR TITLE
BUILD-10772: Changes `fallback-to-default-branch` default to false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
     description: >
       When enabled, automatically adds a fallback restore key pointing to the default branch cache.
       Only applies to the S3 backend.
-    default: 'true'
+    default: 'false'
   backend:
     description: >
       Force cache backend ('github' or 's3'). If not set, falls back to the CACHE_BACKEND environment variable if defined,


### PR DESCRIPTION
## Context of PR

By defaulting it to `fallback-to-default-branch: false`, consumers on the new version of the action will get the same behavior as what is currently in the `v1` branch (no automatic default-branch fallback) until they explicitly opt in by setting `fallback-to-default-branch: true`. This gives them time to evaluate whether they want the new behavior before enabling it.

This is all part of the Release Plan [outlined in Slack here
](https://sonarsource.enterprise.slack.com/archives/C0AMC27AHQ9)

## What Changed?
- Modifies default value of `fallback-to-default-branch` from `true` -> `false`