### PR TITLE
BUILD-10724 fix provision-s3-cache job for tests

### DIFF
--- a/.github/workflows/test-cache-migration-gh2s3.yml
+++ b/.github/workflows/test-cache-migration-gh2s3.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           path: ~/.cache/test-migration
           key: test-migration-s3hit
+          import-github-cache: 'false'
           environment: dev
           backend: s3
 


### PR DESCRIPTION
Fix https://github.com/SonarSource/gh-action_cache/actions/runs/23498187931/job/68385308447#annotation:4:9

In provision-s3-cache, the action has import mode enabled by default. Since S3 was empty on first run, it fell back to GitHub cache and found test-migration-s3hit (saved with github-content by provision-github-cache), restored that, and then the post-step saved github-content to S3 —  overwriting the intended s3-content.

Log confirms:
- Cache not found for input keys: refs/heads/master/test-migration-s3hit
- Cache hit for: test-migration-s3hit          ← GitHub import!
- Cache saved with key: refs/heads/master/test-migration-s3hit  ← saves github-content to S3

 Fix: add `import-github-cache: 'false'` to the provision-s3-cache step so the GitHub import can't interfere.
