### PR TITLE
BUILD-10724 migrate only when S3 is forced

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,20 +69,20 @@ These must be committed since GitHub Actions runs them directly.
 
 ## Inputs
 
-| Input                        | Description                                                                                                                                      | Required | Default |
-|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------|
-| `path`                       | Files, directories, and wildcard patterns to cache                                                                                               | Yes      |         |
-| `key`                        | Explicit key for restoring and saving cache                                                                                                      | Yes      |         |
-| `restore-keys`               | Ordered list of prefix-matched keys for fallback                                                                                                 | No       |         |
-| `fallback-to-default-branch` | Automatically add a fallback restore key pointing to the default branch cache (S3 backend only). Disable if you want strict branch isolation.    | No       | `false` |
-| `fallback-branch`            | Optional maintenance branch for fallback restore keys (pattern: `branch-*`, S3 backend only). If not set, the repository default branch is used. | No       |         |
-| `environment`                | Environment to use (dev or prod, S3 backend only)                                                                                                | No       | `prod`  |
-| `upload-chunk-size`          | Chunk size for large file uploads (bytes)                                                                                                        | No       |         |
-| `enableCrossOsArchive`       | Enable cross-OS cache compatibility                                                                                                              | No       | `false` |
-| `fail-on-cache-miss`         | Fail workflow if cache entry not found                                                                                                           | No       | `false` |
-| `lookup-only`                | Only check cache existence without downloading                                                                                                   | No       | `false` |
-| `backend`                    | Force specific backend: `github` or `s3`. Takes priority over `CACHE_BACKEND` env var and auto-detection.                                        | No       |         |
-| `import-github-cache`        | Import GitHub cache to S3 when no S3 cache exists (migration mode, S3 backend only). Takes priority over `CACHE_IMPORT_GITHUB` env var.          | No       | `true`  |
+| Input                        | Description                                                                                                                                      | Required | Default                                                                      |
+|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------------------------------------------|
+| `path`                       | Files, directories, and wildcard patterns to cache                                                                                               | Yes      |                                                                              |
+| `key`                        | Explicit key for restoring and saving cache                                                                                                      | Yes      |                                                                              |
+| `restore-keys`               | Ordered list of prefix-matched keys for fallback                                                                                                 | No       |                                                                              |
+| `fallback-to-default-branch` | Automatically add a fallback restore key pointing to the default branch cache (S3 backend only). Disable if you want strict branch isolation.    | No       | `false`                                                                      |
+| `fallback-branch`            | Optional maintenance branch for fallback restore keys (pattern: `branch-*`, S3 backend only). If not set, the repository default branch is used. | No       |                                                                              |
+| `environment`                | Environment to use (dev or prod, S3 backend only)                                                                                                | No       | `prod`                                                                       |
+| `upload-chunk-size`          | Chunk size for large file uploads (bytes)                                                                                                        | No       |                                                                              |
+| `enableCrossOsArchive`       | Enable cross-OS cache compatibility                                                                                                              | No       | `false`                                                                      |
+| `fail-on-cache-miss`         | Fail workflow if cache entry not found                                                                                                           | No       | `false`                                                                      |
+| `lookup-only`                | Only check cache existence without downloading                                                                                                   | No       | `false`                                                                      |
+| `backend`                    | Force specific backend: `github` or `s3`. Takes priority over `CACHE_BACKEND` env var and auto-detection.                                        | No       |                                                                              |
+| `import-github-cache`        | Import GitHub cache to S3 when no S3 cache exists (migration mode, S3 backend only). Takes priority over `CACHE_IMPORT_GITHUB` env var.          | No       | `true` when backend is explicitly forced to `s3`, `false` when auto-detected |
 
 ## Backend Selection
 
@@ -107,22 +107,28 @@ Migration mode bridges this gap: when using the S3 backend and no S3 cache exist
 from GitHub Actions cache using the original key. The S3 post-job step then saves the restored content to S3, pre-provisioning it
 for subsequent runs.
 
-Migration mode is **enabled by default** for S3 backend. Once all relevant entries have been migrated to S3, disable it to avoid
-the overhead of the GitHub fallback attempt on every cache miss.
+Migration mode is **enabled by default when the S3 backend is explicitly forced** (`backend: s3` input or `CACHE_BACKEND=s3` env var),
+which is the typical migration scenario. It is disabled by default when the S3 backend is auto-detected (private/internal repository),
+since those repositories have always used S3 and have no GitHub cache entries to migrate.
 
-**Disable resolution order** (first match wins):
+Once all relevant entries have been migrated to S3, disable it to avoid the overhead of the GitHub fallback attempt on every cache miss.
+
+**Resolution order** (first match wins):
 
 1. **`import-github-cache: 'false'`** — action input in the step
 2. **`CACHE_IMPORT_GITHUB=false`** — environment variable at job or workflow level (can be sourced from a repository variable)
-3. Default: `true`
+3. **`true`** if backend was explicitly forced to `s3` (migration scenario)
+4. **`false`** if backend was auto-detected (no prior GitHub cache)
 
 **Disabling via repository variable** (recommended for gradual rollout):
 
 ```yaml
+env:
+  CACHE_BACKEND: s3   # forces S3 for all cache steps, including those in reusable actions
+  CACHE_IMPORT_GITHUB: ${{ vars.CACHE_IMPORT_GITHUB }} # source from repository variable for easy toggle without workflow changes
+
 jobs:
   build:
-    env:
-      CACHE_IMPORT_GITHUB: ${{ vars.CACHE_IMPORT_GITHUB }}
     steps:
       - uses: SonarSource/gh-action_cache@v1
 ```

--- a/action.yml
+++ b/action.yml
@@ -61,10 +61,13 @@ runs:
         REPO_VISIBILITY: ${{ github.event.repository.visibility }}
         FORCED_BACKEND: ${{ inputs.backend }}
       run: |
+        BACKEND_SOURCE="auto"
         if [[ "$FORCED_BACKEND" == "github" || "$FORCED_BACKEND" == "s3" ]]; then
           CACHE_BACKEND="$FORCED_BACKEND"
+          BACKEND_SOURCE="forced"
           echo "Using forced backend from input: $CACHE_BACKEND"
         elif [[ "$CACHE_BACKEND" == "github" || "$CACHE_BACKEND" == "s3" ]]; then
+          BACKEND_SOURCE="forced"
           echo "Using backend from CACHE_BACKEND environment variable: $CACHE_BACKEND"
         else
           # If visibility is not available in the event, try to get it from the API
@@ -85,6 +88,7 @@ runs:
         fi
 
         echo "cache-backend=$CACHE_BACKEND" >> "$GITHUB_OUTPUT"
+        echo "backend-source=$BACKEND_SOURCE" >> "$GITHUB_OUTPUT"
 
     - name: Cache with GitHub Actions (public repos)
       if: steps.cache-backend.outputs.cache-backend == 'github'
@@ -132,17 +136,21 @@ runs:
       shell: bash
       env:
         INPUT_IMPORT_GITHUB_CACHE: ${{ inputs.import-github-cache }}
+        BACKEND_SOURCE: ${{ steps.cache-backend.outputs.backend-source }}
       run: |
-        # Resolution order: input → CACHE_IMPORT_GITHUB env var → default true
+        # Resolution order: input → CACHE_IMPORT_GITHUB env var → true if backend was explicitly forced (migration scenario) → false
         if [[ -n "$INPUT_IMPORT_GITHUB_CACHE" ]]; then
           IMPORT_GITHUB="$INPUT_IMPORT_GITHUB_CACHE"
           echo "Using import mode from input: $IMPORT_GITHUB"
         elif [[ -n "${CACHE_IMPORT_GITHUB:-}" ]]; then
           IMPORT_GITHUB="$CACHE_IMPORT_GITHUB"
           echo "Using import mode from CACHE_IMPORT_GITHUB environment variable: $IMPORT_GITHUB"
-        else
+        elif [[ "$BACKEND_SOURCE" == "forced" ]]; then
           IMPORT_GITHUB="true"
-          echo "Using default import mode: $IMPORT_GITHUB"
+          echo "Using default import mode (backend explicitly forced to S3 — migration scenario): $IMPORT_GITHUB"
+        else
+          IMPORT_GITHUB="false"
+          echo "Using default import mode (backend auto-detected — no prior GitHub cache): $IMPORT_GITHUB"
         fi
         echo "import-github=$IMPORT_GITHUB" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Change the default for `import-github-cache` from always `true` to context-aware:

- **`true`** when the S3 backend was **explicitly forced** via `backend: s3` input or `CACHE_BACKEND=s3` env var — the intentional GitHub→S3 migration scenario.
- **`false`** when the S3 backend was **auto-detected** (private/internal repository) — these repositories have always used S3 and have no GitHub cache entries to migrate.

## Changes

- `action.yml`: `cache-backend` step now emits `backend-source: forced|auto`; `import-mode` step uses it as the smart default.
- `README.md`: updated inputs table and Migration Mode section to document the new default and resolution order.

## Note on future default change

When S3 becomes the default backend for all repositories (including public), the auto-detection case will also need to check repository visibility (`public` → `true`, `private` → `false`). That change is deferred to when the default is actually switched.

## Test coverage

> **gh-action_cache is public** → without explicit backend it auto-detects GitHub, so all S3 scenarios require `backend: s3` or `CACHE_BACKEND=s3`.
> **sonar-dummy is private** → auto-detects S3, needed to test `backend-source=auto` behaviour.

| # | Repo | S3 backend selection | Import mode | S3 cache | Expected | Covered |
|---|------|---------------------|-------------|----------|----------|---------|
| 1 | public | input | true (default) | miss | import from GitHub | ✅ [gh-action_cache](https://github.com/SonarSource/gh-action_cache/blob/master/.github/workflows/test-cache-migration-gh2s3.yml) |
| 2 | public | input | false (input) | miss | no import | ✅ [gh-action_cache](https://github.com/SonarSource/gh-action_cache/blob/master/.github/workflows/test-cache-migration-gh2s3.yml) |
| 3 | public | input | false (env) | miss | no import | ✅ [gh-action_cache](https://github.com/SonarSource/gh-action_cache/blob/master/.github/workflows/test-cache-migration-gh2s3.yml) |
| 4 | public | input | true (default) | hit | S3 content, no import | ✅ [gh-action_cache](https://github.com/SonarSource/gh-action_cache/blob/master/.github/workflows/test-cache-migration-gh2s3.yml) |
| 5 | private | env | true (default) | miss | import from GitHub | ✅ [sonar-dummy#573](https://github.com/SonarSource/sonar-dummy/pull/573) |
| 6 | private | auto | false (default) | miss | no import (new behaviour) | ✅ [sonar-dummy#573](https://github.com/SonarSource/sonar-dummy/pull/573) |
| 7 | private | auto | true (env) | miss | import from GitHub | ✅ [sonar-dummy#573](https://github.com/SonarSource/sonar-dummy/pull/573) |
| 8 | private | auto | true (input) | miss | import from GitHub | ✅ [sonar-dummy#573](https://github.com/SonarSource/sonar-dummy/pull/573) |