### PR TITLE
BUILD-10801: Set S3 as the default backend for all repositories

### DIFF
--- a/.github/workflows/test-cache-migration-gh2s3.yml
+++ b/.github/workflows/test-cache-migration-gh2s3.yml
@@ -146,3 +146,29 @@ jobs:
         run: |
           [[ "${{ steps.cache.outputs.cache-hit }}" == "true" ]] || { echo "ERROR: expected S3 hit"; exit 1; }
           [[ "$(cat ~/.cache/test-migration/test-file.txt)" == "s3-content" ]] || { echo "ERROR: unexpected content — GitHub import may have overridden S3"; exit 1; }
+
+  # Scenario 5: auto-detected S3 (public repo) — GitHub import MUST be triggered via was-github-default=true
+  # Verifies the new code path: public repos switching from GitHub default get migration enabled automatically,
+  # without needing to force the backend explicitly (distinct from the BACKEND_SOURCE=forced path in scenario 1).
+  test-auto-public-import-enabled:
+    needs: provision-github-cache
+    runs-on: github-ubuntu-latest-s
+    name: "Auto-detected S3 (public repo) → GitHub import enabled"
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Cache (auto-detected backend, no backend input or CACHE_BACKEND env)
+        id: cache
+        uses: ./
+        with:
+          path: ~/.cache/test-migration
+          key: test-migration-gh
+          environment: dev
+          # No backend input — public repo auto-detects S3 with was-github-default=true → import enabled
+      - name: Verify import succeeded via was-github-default path
+        run: |
+          [[ "${{ steps.cache.outputs.cache-hit }}" == "true" ]] || { echo "ERROR: cache-hit is not true — GitHub cache was not imported for a public repo"; exit 1; }
+          [[ "$(cat ~/.cache/test-migration/test-file.txt)" == "github-content" ]] || { echo "ERROR: unexpected content, not restored from GitHub"; exit 1; }
+          rm -rf ~/.cache/test-migration  # prevent saving to S3 so other scenarios don't find it

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # `gh-action_cache`
 
-Adaptive cache action that automatically chooses the appropriate caching backend based on repository visibility and ownership.
+Adaptive cache action that uses SonarSource S3 cache for all repositories, with seamless compatibility with the standard GitHub Actions
+cache interface.
 
-- Automatically uses GitHub Actions cache for public repositories
-- Uses SonarSource S3 cache for private/internal SonarSource repositories
+- Uses SonarSource S3 cache for all repositories (public, private, and internal)
 - Seamless API compatibility with standard GitHub Actions cache
 - Supports all standard cache inputs and outputs
-- Automatic repository visibility detection
+- Automatic migration from GitHub Actions cache to S3 (no cold starts)
 
 ## Requirements
 
@@ -69,20 +69,20 @@ These must be committed since GitHub Actions runs them directly.
 
 ## Inputs
 
-| Input                        | Description                                                                                                                                      | Required | Default                                                                      |
-|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------------------------------------------|
-| `path`                       | Files, directories, and wildcard patterns to cache                                                                                               | Yes      |                                                                              |
-| `key`                        | Explicit key for restoring and saving cache                                                                                                      | Yes      |                                                                              |
-| `restore-keys`               | Ordered list of prefix-matched keys for fallback                                                                                                 | No       |                                                                              |
-| `fallback-to-default-branch` | Automatically add a fallback restore key pointing to the default branch cache (S3 backend only). Disable if you want strict branch isolation.    | No       | `true`                                                                      |
-| `fallback-branch`            | Optional maintenance branch for fallback restore keys (pattern: `branch-*`, S3 backend only). If not set, the repository default branch is used. | No       |                                                                              |
-| `environment`                | Environment to use (dev or prod, S3 backend only)                                                                                                | No       | `prod`                                                                       |
-| `upload-chunk-size`          | Chunk size for large file uploads (bytes)                                                                                                        | No       |                                                                              |
-| `enableCrossOsArchive`       | Enable cross-OS cache compatibility                                                                                                              | No       | `false`                                                                      |
-| `fail-on-cache-miss`         | Fail workflow if cache entry not found                                                                                                           | No       | `false`                                                                      |
-| `lookup-only`                | Only check cache existence without downloading                                                                                                   | No       | `false`                                                                      |
-| `backend`                    | Force specific backend: `github` or `s3`. Takes priority over `CACHE_BACKEND` env var and auto-detection.                                        | No       |                                                                              |
-| `import-github-cache`        | Import GitHub cache to S3 when no S3 cache exists (migration mode, S3 backend only). Takes priority over `CACHE_IMPORT_GITHUB` env var.          | No       | `true` when backend is explicitly forced to `s3`, `false` when auto-detected |
+| Input                        | Description                                                                                                                                      | Required | Default                                                                                                  |
+|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------------------------------------------------------------------------------------------------------|
+| `path`                       | Files, directories, and wildcard patterns to cache                                                                                               | Yes      |                                                                                                          |
+| `key`                        | Explicit key for restoring and saving cache                                                                                                      | Yes      |                                                                                                          |
+| `restore-keys`               | Ordered list of prefix-matched keys for fallback                                                                                                 | No       |                                                                                                          |
+| `fallback-to-default-branch` | Automatically add a fallback restore key pointing to the default branch cache (S3 backend only). Disable if you want strict branch isolation.    | No       | `true`                                                                                                   |
+| `fallback-branch`            | Optional maintenance branch for fallback restore keys (pattern: `branch-*`, S3 backend only). If not set, the repository default branch is used. | No       |                                                                                                          |
+| `environment`                | Environment to use (dev or prod, S3 backend only)                                                                                                | No       | `prod`                                                                                                   |
+| `upload-chunk-size`          | Chunk size for large file uploads (bytes)                                                                                                        | No       |                                                                                                          |
+| `enableCrossOsArchive`       | Enable cross-OS cache compatibility                                                                                                              | No       | `false`                                                                                                  |
+| `fail-on-cache-miss`         | Fail workflow if cache entry not found                                                                                                           | No       | `false`                                                                                                  |
+| `lookup-only`                | Only check cache existence without downloading                                                                                                   | No       | `false`                                                                                                  |
+| `backend`                    | Force specific backend: `github` or `s3`. Takes priority over `CACHE_BACKEND` env var and auto-detection.                                        | No       |                                                                                                          |
+| `import-github-cache`        | Import GitHub cache to S3 when no S3 cache exists (migration mode, S3 backend only). Takes priority over `CACHE_IMPORT_GITHUB` env var.          | No       | `true` when backend is explicitly forced to `s3` or for public repos; `false` for private/internal repos |
 
 ## Backend Selection
 
@@ -90,7 +90,7 @@ The cache backend is determined in the following priority order:
 
 1. **`inputs.backend`** — explicit input in the action step (`github` or `s3`)
 2. **`CACHE_BACKEND` environment variable** — set at the job or workflow level (`github` or `s3`)
-3. **Repository visibility** — `github` for public repos, `s3` for private/internal repos
+3. **Default** — `s3` for all repositories (public, private, and internal)
 
 The `CACHE_BACKEND` env var is useful when the cache action is called indirectly through a composite action, and you cannot set the
 `backend` input directly, or when you want to enforce the same backend for all cache steps in a workflow without modifying each step:
@@ -107,9 +107,14 @@ Migration mode bridges this gap: when using the S3 backend and no S3 cache exist
 from GitHub Actions cache using the original key. The S3 post-job step then saves the restored content to S3, pre-provisioning it
 for subsequent runs.
 
-Migration mode is **enabled by default when the S3 backend is explicitly forced** (`backend: s3` input or `CACHE_BACKEND=s3` env var),
-which is the typical migration scenario. It is disabled by default when the S3 backend is auto-detected (private/internal repository),
-since those repositories have always used S3 and have no GitHub cache entries to migrate.
+Migration mode is **enabled by default** in two cases:
+
+- **Backend explicitly forced to S3** (`backend: s3` input or `CACHE_BACKEND=s3` env var) — the typical opt-in migration scenario.
+- **Public repository with auto-detected backend** — public repositories previously used GitHub Actions cache by default; migration
+  is enabled automatically so their first run after the upgrade remains a warm cache hit.
+
+It is **disabled by default** for private/internal repositories with auto-detected backend, since those repositories have always
+used S3 and have no GitHub cache entries to migrate.
 
 Once all relevant entries have been migrated to S3, disable it to avoid the overhead of the GitHub fallback attempt on every cache miss.
 
@@ -117,8 +122,9 @@ Once all relevant entries have been migrated to S3, disable it to avoid the over
 
 1. **`import-github-cache: 'false'`** — action input in the step
 2. **`CACHE_IMPORT_GITHUB=false`** — environment variable at job or workflow level (can be sourced from a repository variable)
-3. **`true`** if backend was explicitly forced to `s3` (migration scenario)
-4. **`false`** if backend was auto-detected (no prior GitHub cache)
+3. **`true`** if backend was explicitly forced to `s3` (opt-in migration scenario)
+4. **`true`** if backend was auto-detected and repository is **public** (previously used GitHub cache by default)
+5. **`false`** if backend was auto-detected and repository is **private/internal** (always used S3, no GitHub cache to migrate)
 
 **Disabling via repository variable** (recommended for gradual rollout):
 

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,7 @@ runs:
         FORCED_BACKEND: ${{ inputs.backend }}
       run: |
         BACKEND_SOURCE="auto"
+        WAS_GITHUB_DEFAULT="false"
         if [[ "$FORCED_BACKEND" == "github" || "$FORCED_BACKEND" == "s3" ]]; then
           CACHE_BACKEND="$FORCED_BACKEND"
           BACKEND_SOURCE="forced"
@@ -78,17 +79,18 @@ runs:
           fi
           echo "Repository visibility: $REPO_VISIBILITY"
 
+          CACHE_BACKEND="s3"
           if [[ "$REPO_VISIBILITY" == "public" ]]; then
-            CACHE_BACKEND="github"
-            echo "Using GitHub cache for public repository"
+            WAS_GITHUB_DEFAULT="true"
+            echo "Using S3 cache for public repository (previously GitHub default — migration eligible)"
           else
-            CACHE_BACKEND="s3"
             echo "Using S3 cache for private/internal repository"
           fi
         fi
 
         echo "cache-backend=$CACHE_BACKEND" >> "$GITHUB_OUTPUT"
         echo "backend-source=$BACKEND_SOURCE" >> "$GITHUB_OUTPUT"
+        echo "was-github-default=$WAS_GITHUB_DEFAULT" >> "$GITHUB_OUTPUT"
 
     - name: Cache with GitHub Actions (public repos)
       if: steps.cache-backend.outputs.cache-backend == 'github'
@@ -137,8 +139,10 @@ runs:
       env:
         INPUT_IMPORT_GITHUB_CACHE: ${{ inputs.import-github-cache }}
         BACKEND_SOURCE: ${{ steps.cache-backend.outputs.backend-source }}
+        WAS_GITHUB_DEFAULT: ${{ steps.cache-backend.outputs.was-github-default }}
       run: |
-        # Resolution order: input → CACHE_IMPORT_GITHUB env var → true if backend was explicitly forced (migration scenario) → false
+        # Resolution order: input → CACHE_IMPORT_GITHUB env var → true if backend was explicitly forced (migration scenario)
+        #                 → true if public repo switching from GitHub default → false (private/internal, already on S3)
         if [[ -n "$INPUT_IMPORT_GITHUB_CACHE" ]]; then
           IMPORT_GITHUB="$INPUT_IMPORT_GITHUB_CACHE"
           echo "Using import mode from input: $IMPORT_GITHUB"
@@ -148,9 +152,12 @@ runs:
         elif [[ "$BACKEND_SOURCE" == "forced" ]]; then
           IMPORT_GITHUB="true"
           echo "Using default import mode (backend explicitly forced to S3 — migration scenario): $IMPORT_GITHUB"
+        elif [[ "$WAS_GITHUB_DEFAULT" == "true" ]]; then
+          IMPORT_GITHUB="true"
+          echo "Using default import mode (public repository — previously used GitHub cache by default): $IMPORT_GITHUB"
         else
           IMPORT_GITHUB="false"
-          echo "Using default import mode (backend auto-detected — no prior GitHub cache): $IMPORT_GITHUB"
+          echo "Using default import mode (private/internal repository — already on S3): $IMPORT_GITHUB"
         fi
         echo "import-github=$IMPORT_GITHUB" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

- Removes the visibility-based split (public→GitHub, private→S3) in the auto-detection step; all repositories now default to S3
- Adds a `was-github-default` output from the backend-detection step to identify public repos that previously used GitHub cache by default
- Extends migration mode detection: in addition to explicitly forced S3, public repos with auto-detected S3 also enable import by default (they had GitHub cache entries to migrate)
- Updates README accordingly: intro, Backend Selection, `import-github-cache` default description, and Migration Mode resolution order
- Adds test scenario 5 to `test-cache-migration-gh2s3.yml`: auto-detected S3 on a public repo triggers GitHub import via `was-github-default=true` (distinct from the `backend-source=forced` path in scenario 1)

## Test plan

CI-covered:

- [x] Auto-detected S3 (public repo) → GitHub import enabled (`test-auto-public-import-enabled`)
- [x] Auto-detected S3, forced `backend: s3` → migration enabled (`test-s3-import-enabled`)
- [x] `import-github-cache: false` input → migration disabled (`test-s3-import-disabled`)
- [x] `CACHE_IMPORT_GITHUB=false` env var → migration disabled (`test-s3-import-disabled-via-env`)
- [x] S3 hit → GitHub import skipped (`test-s3-hit-skips-github-import`)
- [x] `backend: github` input → GitHub backend (`test-action.yml`)

Manual — will be covered after merge, before release, via dogfooding on the dummy repositories:

- [x] Public repo, no override → S3 backend, migration enabled
- [x] Any repo, `CACHE_BACKEND=github` env var → GitHub backend