### PR TITLE
PREQ-5729: fix argument list too long in cache cleanup

### DIFF
--- a/scripts/cleanup-cache.sh
+++ b/scripts/cleanup-cache.sh
@@ -212,8 +212,9 @@ echo "Deleting ${MATCH_COUNT} object(s)..."
 
 BATCH_SIZE=1000
 KEYS_FILE=$(mktemp)
+DELETE_FILE=""
 echo "$MATCHED_KEYS" > "$KEYS_FILE"
-trap 'rm -f "$KEYS_FILE"' EXIT
+trap 'rm -f "$KEYS_FILE" "${DELETE_FILE:-}"' EXIT
 
 DELETED=0
 while true; do
@@ -232,10 +233,10 @@ while true; do
     --bucket "${S3_BUCKET}" \
     --delete "file://$DELETE_FILE" > /dev/null || {
     echo "ERROR: Failed to delete batch of objects" >&2
-    rm -f "$DELETE_FILE"
     exit 1
   }
   rm -f "$DELETE_FILE"
+  DELETE_FILE=""
 
   BATCH_COUNT=$(echo "$BATCH" | wc -l | tr -d ' ')
   DELETED=$((DELETED + BATCH_COUNT))

--- a/scripts/cleanup-cache.sh
+++ b/scripts/cleanup-cache.sh
@@ -222,17 +222,20 @@ while true; do
     break
   fi
 
-  DELETE_JSON=$(echo "$BATCH" | jq -R -s '
+  DELETE_FILE=$(mktemp)
+  echo "$BATCH" | jq -R -s '
     split("\n") | map(select(length > 0)) |
     { Objects: map({ Key: . }), Quiet: true }
-  ')
+  ' > "$DELETE_FILE"
 
   aws s3api delete-objects \
     --bucket "${S3_BUCKET}" \
-    --delete "$DELETE_JSON" > /dev/null || {
+    --delete "file://$DELETE_FILE" > /dev/null || {
     echo "ERROR: Failed to delete batch of objects" >&2
+    rm -f "$DELETE_FILE"
     exit 1
   }
+  rm -f "$DELETE_FILE"
 
   BATCH_COUNT=$(echo "$BATCH" | wc -l | tr -d ' ')
   DELETED=$((DELETED + BATCH_COUNT))


### PR DESCRIPTION
## Summary

- Fixes `Argument list too long` error when running cache cleanup on repos with large caches (e.g. sonar-enterprise with 1 TB+ cache)
- Writes the delete JSON payload to a temp file and passes it via `file://` URI instead of inline shell argument, avoiding OS `ARG_MAX` limits

## Root cause

`aws s3api delete-objects --delete "$DELETE_JSON"` passes the entire JSON blob as a process argument. When S3 keys are long and there are up to 1000 per batch, this exceeds the kernel argument size limit (~2 MB on Linux).

## Fix

Use `file://` as [documented by AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-objects.html):
```bash
aws s3api delete-objects --bucket "$BUCKET" --delete "file://$DELETE_FILE"
```

## Test plan

- [ ] Run cache cleanup on sonar-enterprise master branch (the failing case from PREQ-5729)
- [ ] Verify cleanup completes without `Argument list too long` error