### PR TITLE
BUILD-10835 Migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/check-cache-migration.yml
+++ b/.github/workflows/check-cache-migration.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check-migration:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Compare GitHub cache vs S3
     permissions:
       id-token: write

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: SonarSource/gh-action_pre-commit@fc9d73025994fd1c2b96d568c8c8a4af82a3ae21 # 1.0.6
         with:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-github-cache:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read
@@ -41,7 +41,7 @@ jobs:
       run: python -m pytest --version
 
   test-s3-cache:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read
@@ -76,7 +76,7 @@ jobs:
         run: python -m pytest --version
 
   test-s3-cache-with-fallback:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read
@@ -122,7 +122,7 @@ jobs:
       run: go build -o hello main.go
 
   test-s3-cache-with-credential-interference:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read
@@ -190,7 +190,7 @@ jobs:
 
   # Reproduces: ~/.aws/config corruption from multiple credential_process entries
   test-s3-cache-multiple-invocations:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read
@@ -232,7 +232,7 @@ jobs:
   # Reproduces: pre-existing AWS config from configure-aws-credentials
   # https://github.com/SonarSource/sonarsource-iam/actions/runs/21951781857/job/63404298650#step:5:9
   test-s3-cache-with-preset-aws-config:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read
@@ -301,7 +301,7 @@ jobs:
   # Regression test: git clean -ffdx must not break credential-guard post step
   # Reproduces: https://github.com/SonarSource/sonar-dummy/actions/runs/21997126216
   test-s3-cache-survives-git-clean:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read
@@ -347,7 +347,7 @@ jobs:
       - test-s3-cache-multiple-invocations
       - test-s3-cache-with-preset-aws-config
       - test-s3-cache-survives-git-clean
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2

--- a/.github/workflows/test-cache-migration-gh2s3.yml
+++ b/.github/workflows/test-cache-migration-gh2s3.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # Prerequisite: provision GitHub cache entries used by the test scenarios
   provision-github-cache:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: "Provision GitHub cache entries"
     permissions:
       contents: read
@@ -31,7 +31,7 @@ jobs:
 
   # Prerequisite: provision an S3 cache entry for the S3-hit scenario
   provision-s3-cache:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: "Provision S3 cache entry"
     permissions:
       id-token: write
@@ -52,7 +52,7 @@ jobs:
   # Scenario 1: S3 backend with import mode active (default behavior after migration begins)
   test-s3-import-enabled:
     needs: provision-github-cache
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: "S3 + import enabled (migration fallback)"
     permissions:
       id-token: write
@@ -77,7 +77,7 @@ jobs:
   # Scenario 2: S3 backend with import mode explicitly disabled
   test-s3-import-disabled:
     needs: provision-github-cache
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: "S3 + import disabled (migration complete)"
     permissions:
       id-token: write
@@ -101,7 +101,7 @@ jobs:
   # Scenario 3: S3 backend with import disabled via env var (repo variable pattern)
   test-s3-import-disabled-via-env:
     needs: provision-github-cache
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: "S3 + import disabled via env var"
     permissions:
       id-token: write
@@ -126,7 +126,7 @@ jobs:
   # Scenario 4: S3 hit — GitHub import step must be skipped entirely
   test-s3-hit-skips-github-import:
     needs: [ provision-github-cache, provision-s3-cache ]
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: "S3 hit → no GitHub import"
     permissions:
       id-token: write
@@ -152,7 +152,7 @@ jobs:
   # without needing to force the backend explicitly (distinct from the BACKEND_SOURCE=forced path in scenario 1).
   test-auto-public-import-enabled:
     needs: provision-github-cache
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: "Auto-detected S3 (public repo) → GitHub import enabled"
     permissions:
       id-token: write
@@ -184,7 +184,7 @@ jobs:
       - test-s3-import-disabled-via-env
       - test-s3-hit-skips-github-import
       - test-auto-public-import-enabled
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2

--- a/.github/workflows/test-credential-isolation.yml
+++ b/.github/workflows/test-credential-isolation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tests-credential-isolation:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
BUILD-10835 This change moves CI from GitHub-hosted Ubuntu runner labels to the shared WarpBuild image `warp-custom-ubuntu-24-04`, in line with the platform runner migration.

## Summary

- Replaces `github-ubuntu-latest-*` with `warp-custom-ubuntu-24-04` in the workflows listed in the migration scan.

## Files

- `.github/workflows/check-cache-migration.yml`
- `.github/workflows/cleanup-cache.yml`
- `.github/workflows/pre-commit.yml`
- `.github/workflows/test-action.yml`
- `.github/workflows/test-cache-migration-gh2s3.yml`
- `.github/workflows/test-credential-isolation.yml`

## Notes for reviewers

- No intentional changes to job logic, permissions, or steps beyond `runs-on` / default runner strings.
- Please confirm workflows still match org expectations for this repository after merge.
