### PR TITLE
BUILD-11297 Simplify CI_METRICS_ENABLED gate — strict 'true', no bash step

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ These must be committed since GitHub Actions runs them directly.
 
 ### Input Environment Variables
 
-| Environment Variable | Description |
-| --- | --- |
-| `CACHE_BACKEND` | Force specific backend: `github` or `s3` (overrides auto-detection). |
-| `CACHE_IMPORT_GITHUB` | Disable GitHub cache fallback for S3 backend (migration mode) when set to `false`. |
-| `CI_METRICS_ENABLED` | Opt-in feature flag for pipeline runtime metrics (Linux only). Set to `true` (case-insensitive) to enable emission of the `cache-size-bytes` output and the per-invocation JSON record at `${CI_METRICS_DIR}/cache-*.json`. Unset, empty, or any other value: metrics disabled, cache flow unchanged. |
-| `CI_METRICS_DIR` | Output directory for the per-invocation metrics JSON (only consulted when `CI_METRICS_ENABLED=true`). Provided by the ARC pod template / WarpBuild AMI; defaults to `/tmp/ci-metrics` when unset or empty. |
+| Environment Variable  | Description                                                                                                                                                                                                |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `CACHE_BACKEND`       | Force specific backend: `github` or `s3` (overrides auto-detection).                                                                                                                                       |
+| `CACHE_IMPORT_GITHUB` | Disable GitHub cache fallback for S3 backend (migration mode) when set to `false`.                                                                                                                         |
+| `CI_METRICS_ENABLED`  | Opt-in feature flag for pipeline runtime metrics (Linux only). Set to `true` to enable emission of the `cache-size-bytes` output and the per-invocation JSON record at `${CI_METRICS_DIR}/cache-*.json`.   |
+| `CI_METRICS_DIR`      | Output directory for the per-invocation metrics JSON (only consulted when `CI_METRICS_ENABLED=true`). Provided by the ARC pod template / WarpBuild AMI; defaults to `/tmp/ci-metrics` when unset or empty. |
 
 ## Inputs
 
@@ -189,17 +189,14 @@ gh variable set CACHE_IMPORT_GITHUB --body "true"
 
 ### Pipeline runtime metrics
 
-On Linux runners — and **only when the `CI_METRICS_ENABLED` environment variable is set to `true`**
-(case-insensitive) — the action writes a per-invocation JSON record to `${CI_METRICS_DIR}/cache-${step}.json`
-for the [pipeline runtime metrics](https://sonarsource.atlassian.net/browse/BUILD-11068) `job-completed.sh`
-hook to ingest. The output directory is taken from the `CI_METRICS_DIR` environment variable (provided by the
+On Linux runners — and only when `CI_METRICS_ENABLED` is set to `true` — the action writes a per-invocation JSON record to
+`${CI_METRICS_DIR}/cache-${step}.json` for the [pipeline runtime metrics](https://sonarsource.atlassian.net/browse/BUILD-11068)
+`job-completed.sh` hook to ingest. The output directory is taken from the `CI_METRICS_DIR` environment variable (provided by the
 ARC pod template / WarpBuild AMI); it falls back to `/tmp/ci-metrics` when the variable is unset or empty.
-The record captures both the restore-time size and the pre-save size, plus whether the cache was actually
-saved.
+The record captures both the restore-time size and the pre-save size, plus whether the cache was actually saved.
 
-When `CI_METRICS_ENABLED` is unset or set to anything other than `true`, the cache flow runs exactly as
-before — no metrics steps, no JSON file, and `cache-size-bytes` is empty. The other outputs (`cache-hit`,
-`cache-matched-key`, `restore-key-hit`, `backend`) are unaffected.
+When `CI_METRICS_ENABLED` is unset or set to anything other than `true`, the cache flow runs exactly as before — no metrics steps, no JSON
+file, and `cache-size-bytes` is empty. The other outputs (`cache-hit`, `cache-matched-key`, `restore-key-hit`, `backend`) are unaffected.
 
 **Example — partial restore-key hit (primary missed, prefix-matched older entry restored, then re-saved under primary key):**
 

--- a/action.yml
+++ b/action.yml
@@ -245,24 +245,10 @@ runs:
         echo "cache-hit=${CACHE_HIT}" >> "$GITHUB_OUTPUT"
         echo "matched-key=${MATCHED_KEY}" >> "$GITHUB_OUTPUT"
 
-    # Feature flag: cache-metrics is opt-in via the CI_METRICS_ENABLED env var (case-insensitive `true`). The runner pod template /
-    # WarpBuild AMI sets it for the repos that are part of the BUILD-11068 pilot; everywhere else, the cache flow runs unchanged and no
-    # metrics are emitted.
-    - name: Resolve CI_METRICS_ENABLED flag
-      id: metrics-flag
-      shell: bash
-      env:
-        RAW: ${{ env.CI_METRICS_ENABLED }}
-      run: |
-        if [[ "${RAW,,}" == "true" ]]; then
-          echo "enabled=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "enabled=false" >> "$GITHUB_OUTPUT"
-        fi
-
+    # CI_METRICS_ENABLED is set by the runner pod template / WarpBuild AMI for the BUILD-11068 pilot repos.
     - name: Prepare local cache-metrics sub-action
       id: cache-metrics-prep
-      if: runner.os == 'Linux' && steps.metrics-flag.outputs.enabled == 'true'
+      if: runner.os == 'Linux' && env.CI_METRICS_ENABLED == 'true'
       shell: bash
       # Fail-open: the metrics flow must never break the cache flow. The next step's `if:` will skip gracefully if preparation fails.
       run: |

--- a/cache-metrics/action.yml
+++ b/cache-metrics/action.yml
@@ -32,7 +32,6 @@ runs:
   using: node20
   main: dist/main/index.js
   post: dist/post/index.js
-  # Run the post step even when an earlier step in the job failed — metrics are
-  # most useful precisely when something went wrong, and the cache-metrics post
-  # step is fail-open (cannot break the cache flow on its own).
+  # Run the post step even when an earlier step in the job failed — metrics are most useful precisely when something went wrong, and the
+  # cache-metrics post step is fail-open (cannot break the cache flow on its own).
   post-if: always()


### PR DESCRIPTION
## Summary

Fix a regression introduced by [#62](https://github.com/SonarSource/gh-action_cache/pull/62) (BUILD-11294 — cache metrics): the `metrics-flag` shell step crashed on macOS runners with `bad substitution` because `${VAR,,}` lowercase substitution is bash 4+ only (Apple ships bash 3.2). The crash cascaded into a template-validity error for downstream `build-maven` `if:` expressions in consumer workflows.

**Observed in:** [sonar-dummy#592 Build macOS, run 26091741374, step 5 line 884](https://github.com/SonarSource/sonar-dummy/actions/runs/26091741374/job/76718969168?pr=592#step:5:884).

## Fix

Drop the bash step entirely; check `env.CI_METRICS_ENABLED == 'true'` directly in the `cache-metrics-prep` step's `if:` expression.

- **No more bash** — zero portability surface across runner platforms.
- **Strict literal `'true'`** — matches the convention of the existing env vars in this action (`CACHE_BACKEND`, `CACHE_IMPORT_GITHUB`). The earlier case-insensitive logic (`${VAR,,} == 'true'` accepting `True` / `TRUE` / `true`) was an artifact of bash 4 only; GHA expressions don't have `tolower`, so encoding the same semantic in YAML would require listing variants explicitly. Strict `'true'` is simpler and consistent.
- **Linux-only scope preserved** — the combined `if: runner.os == 'Linux' && env.CI_METRICS_ENABLED == 'true'` keeps the metrics flow Linux-only. The downstream `cache-metrics` step continues to chain on `steps.cache-metrics-prep.outputs.prepared == 'true'`, so when the flag is unset or non-`'true'` the entire pipeline is skipped without warning.

## Why ship this now (separate from M2 macOS compliance)

The metrics-flag bash step ran **unconditionally on every consumer call** to `gh-action_cache@master`. On macOS, bash 3.2 errored on `${RAW,,}` regardless of whether `CI_METRICS_ENABLED` was set — i.e. this broke the base cache flow on macOS for everyone, not just metrics-pilot repos. Restoring base-flow correctness is independent of (and prerequisite to) the M2 work that will add macOS metrics emission.

## Behavior on non-Linux after this fix

- `CI_METRICS_ENABLED=true` set, macOS/Windows runner: cache flow runs unchanged (as it did before #62). No metrics emission, no JSON written, no crash. Matches the documented "Linux only" promise in the README.
- macOS metrics emission remains scoped to M2 (BUILD-11298–11300, WarpBuild AMI work).

## Test plan

- [x] Vitest suite green (48 cases)
- [x] All lines in `action.yml`, `cache-metrics/action.yml` ≤ 140 cols
- [x] Markdownlint clean on README
- [ ] CI on this branch
- [ ] Consumer dogfood: sonar-dummy macOS job no longer crashes

## Related

- Parent epic: [BUILD-11068](https://sonarsource.atlassian.net/browse/BUILD-11068)
- Pilot rollout ticket: [BUILD-11297](https://sonarsource.atlassian.net/browse/BUILD-11297) (M1.9, surfaced this bug on sonar-dummy macOS)
- Original PR: [#62](https://github.com/SonarSource/gh-action_cache/pull/62) (BUILD-11294)
- Consumer dogfood: [SonarSource/sonar-dummy#592](https://github.com/SonarSource/sonar-dummy/pull/592)
- Future macOS metrics emission: [BUILD-11298](https://sonarsource.atlassian.net/browse/BUILD-11298) – [BUILD-11300](https://sonarsource.atlassian.net/browse/BUILD-11300) (M2, WarpBuild AMI)

[BUILD-11068]: https://sonarsource.atlassian.net/browse/BUILD-11068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ