### PR TITLE
BUILD-11297 Fix container self-reference and pre-commit git-clean regressions

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -333,6 +333,43 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest requests
 
+  # Regression test: with CI_METRICS_ENABLED, the cache-metrics post step must still find
+  # `./.actions/cache-metrics` after another action runs actions/checkout (clean + reset + force-checkout),
+  # which is what wiped the symlink in https://github.com/SonarSource/sonar-dummy/actions/runs/26102811096/job/76758257880
+  test-s3-cache-survives-git-clean-with-metrics:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CI_METRICS_ENABLED: 'true'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          version: 2025.7.12
+
+      - name: Cache with S3 (metrics enabled)
+        id: cache-test
+        uses: ./
+        with:
+          path: ~/.cache/pip
+          key: git-clean-metrics-test-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: git-clean-metrics-test-${{ runner.os }}-
+          environment: dev
+          backend: s3
+
+      # Simulate what a nested actions/checkout does (clean → reset --hard → fetch → checkout --force).
+      # This is the sequence that wiped `.actions/cache-metrics` from the workspace between main and post
+      # in the pre-commit job — the `git add -f .actions` workaround survives the clean but not the reset.
+      - name: Re-run actions/checkout (simulates nested action's checkout)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Create something to cache
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest requests
+
       # SUCCESS: credential-guard post step runs, then runs-on/cache saves to S3
 
   # Validates cache-size-bytes output + ${CI_METRICS_DIR}/cache-*.json (gated by CI_METRICS_ENABLED).
@@ -400,6 +437,7 @@ jobs:
       - test-s3-cache-multiple-invocations
       - test-s3-cache-with-preset-aws-config
       - test-s3-cache-survives-git-clean
+      - test-s3-cache-survives-git-clean-with-metrics
       - test-cache-metrics-output
     runs-on: github-ubuntu-latest-s
     steps:

--- a/__tests__/credential-guard.test.ts
+++ b/__tests__/credential-guard.test.ts
@@ -35,6 +35,33 @@ describe('credential-guard-main', () => {
     );
   });
 
+  it('saves cache-metrics-action-path to GITHUB_STATE when provided', async () => {
+    const credsPath = path.join(os.tmpdir(), 'creds', 'credentials.json');
+    const metricsPath = path.join(os.tmpdir(), 'action', 'cache-metrics');
+    const inputs: Record<string, string> = {
+      'credentials-file': credsPath,
+      'cache-metrics-action-path': metricsPath,
+    };
+    vi.mocked(core.getInput).mockImplementation((name: string) => inputs[name] ?? '');
+
+    const { run } = await import('../src/credential-guard-main');
+    await run();
+
+    expect(core.saveState).toHaveBeenCalledWith('cache-metrics-action-path', metricsPath);
+  });
+
+  it('does not save cache-metrics-action-path state when input is empty', async () => {
+    const inputs: Record<string, string> = {
+      'credentials-file': path.join(os.tmpdir(), 'creds.json'),
+    };
+    vi.mocked(core.getInput).mockImplementation((name: string) => inputs[name] ?? '');
+
+    const { run } = await import('../src/credential-guard-main');
+    await run();
+
+    expect(core.saveState).not.toHaveBeenCalledWith('cache-metrics-action-path', expect.anything());
+  });
+
   it('fails when credentials-file input is missing', async () => {
     vi.mocked(core.getInput).mockImplementation(() => {
       throw new Error('Input required and not supplied: credentials-file');
@@ -99,13 +126,16 @@ describe('credential-guard-post', () => {
     expect(core.exportVariable).not.toHaveBeenCalled();
   });
 
-  it('warns if no state was saved', async () => {
+  it('logs and exits cleanly when no state was saved', async () => {
+    // Demoted from warning to info: credential-guard-post now also handles the cache-metrics
+    // symlink keeper, so an empty credentials-file is the normal no-op path on non-S3 runs.
     vi.mocked(core.getState).mockReturnValue('');
 
     const { run } = await import('../src/credential-guard-post');
     await run();
 
-    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('No credentials file'));
+    expect(core.info).toHaveBeenCalledWith(expect.stringContaining('No credentials file'));
+    expect(core.exportVariable).not.toHaveBeenCalled();
   });
 
   it('writes ~/.aws/credentials with correct INI format', async () => {
@@ -201,6 +231,85 @@ describe('credential-guard-post', () => {
     expect(core.info).toHaveBeenCalledWith(
       'Wrote credentials to ~/.aws/credentials [default] profile (fallback for nested composites)'
     );
+  });
+
+  it('symlink keeper: skips when target is empty (CI_METRICS_ENABLED unset)', async () => {
+    vi.mocked(core.getState).mockReturnValue('');
+
+    const { ensureCacheMetricsSymlink } = await import('../src/credential-guard-post');
+    await ensureCacheMetricsSymlink('');
+
+    expect(core.warning).not.toHaveBeenCalled();
+    expect(core.info).not.toHaveBeenCalled();
+  });
+
+  it('symlink keeper: leaves existing symlink alone when target action.yml is reachable', async () => {
+    // Layout: <tmp>/source/cache-metrics/action.yml is the canonical target.
+    //         <tmp>/workspace/.actions/cache-metrics is an existing symlink to it.
+    const source = path.join(tmpDir, 'source', 'cache-metrics');
+    await fs.mkdir(source, { recursive: true });
+    await fs.writeFile(path.join(source, 'action.yml'), 'name: dummy\n');
+    const workspace = path.join(tmpDir, 'workspace');
+    await fs.mkdir(path.join(workspace, '.actions'), { recursive: true });
+    await fs.symlink(source, path.join(workspace, '.actions', 'cache-metrics'));
+
+    const prevCwd = process.cwd();
+    process.chdir(workspace);
+    try {
+      const { ensureCacheMetricsSymlink } = await import('../src/credential-guard-post');
+      await ensureCacheMetricsSymlink(source);
+    } finally {
+      process.chdir(prevCwd);
+    }
+
+    // No recreation log fired — the existing symlink was left untouched.
+    expect(core.info).not.toHaveBeenCalledWith(expect.stringContaining('recreated'));
+    // Sanity: still a symlink pointing at source.
+    const linkTarget = await fs.readlink(path.join(workspace, '.actions', 'cache-metrics'));
+    expect(linkTarget).toBe(source);
+  });
+
+  it('symlink keeper: recreates the symlink when missing', async () => {
+    const source = path.join(tmpDir, 'source', 'cache-metrics');
+    await fs.mkdir(source, { recursive: true });
+    await fs.writeFile(path.join(source, 'action.yml'), 'name: dummy\n');
+    const workspace = path.join(tmpDir, 'workspace');
+    await fs.mkdir(workspace, { recursive: true });
+
+    const prevCwd = process.cwd();
+    process.chdir(workspace);
+    try {
+      const { ensureCacheMetricsSymlink } = await import('../src/credential-guard-post');
+      await ensureCacheMetricsSymlink(source);
+    } finally {
+      process.chdir(prevCwd);
+    }
+
+    const linkTarget = await fs.readlink(path.join(workspace, '.actions', 'cache-metrics'));
+    expect(linkTarget).toBe(source);
+    expect(core.info).toHaveBeenCalledWith(expect.stringContaining('recreated'));
+  });
+
+  it('symlink keeper: warns and skips when target action.yml is missing', async () => {
+    const missingSource = path.join(tmpDir, 'no-such-source', 'cache-metrics');
+    const workspace = path.join(tmpDir, 'workspace');
+    await fs.mkdir(workspace, { recursive: true });
+
+    const prevCwd = process.cwd();
+    process.chdir(workspace);
+    try {
+      const { ensureCacheMetricsSymlink } = await import('../src/credential-guard-post');
+      await ensureCacheMetricsSymlink(missingSource);
+    } finally {
+      process.chdir(prevCwd);
+    }
+
+    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('target action.yml missing'));
+    const linkExists = await fs
+      .access(path.join(workspace, '.actions', 'cache-metrics'))
+      .then(() => true)
+      .catch(() => false);
+    expect(linkExists).toBe(false);
   });
 
   it('does not write ~/.aws/credentials when credentials are missing fields', async () => {

--- a/action.yml
+++ b/action.yml
@@ -72,14 +72,16 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Determine cache backend
+    - name: Determine cache backend and import mode
       id: cache-backend
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
         REPO_VISIBILITY: ${{ github.event.repository.visibility }}
         FORCED_BACKEND: ${{ inputs.backend }}
+        INPUT_IMPORT_GITHUB_CACHE: ${{ inputs.import-github-cache }}
       run: |
+        echo "::group::Resolve backend"
         BACKEND_SOURCE="auto"
         WAS_GITHUB_DEFAULT="false"
         if [[ "$FORCED_BACKEND" == "github" || "$FORCED_BACKEND" == "s3" ]]; then
@@ -105,9 +107,35 @@ runs:
             echo "Using S3 cache for private/internal repository"
           fi
         fi
-        echo "cache-backend=$CACHE_BACKEND" >> "$GITHUB_OUTPUT"
-        echo "backend-source=$BACKEND_SOURCE" >> "$GITHUB_OUTPUT"
-        echo "was-github-default=$WAS_GITHUB_DEFAULT" >> "$GITHUB_OUTPUT"
+        echo "::endgroup::"
+
+        echo "::group::Resolve GitHub cache import mode"
+        # Resolution order: input → CACHE_IMPORT_GITHUB env var → true if backend was explicitly forced (migration scenario)
+        #                 → true if public repo switching from GitHub default → false (private/internal, already on S3)
+        if [[ -n "$INPUT_IMPORT_GITHUB_CACHE" ]]; then
+          IMPORT_GITHUB="$INPUT_IMPORT_GITHUB_CACHE"
+          echo "Using import mode from input: $IMPORT_GITHUB"
+        elif [[ -n "${CACHE_IMPORT_GITHUB:-}" ]]; then
+          IMPORT_GITHUB="$CACHE_IMPORT_GITHUB"
+          echo "Using import mode from CACHE_IMPORT_GITHUB environment variable: $IMPORT_GITHUB"
+        elif [[ "$BACKEND_SOURCE" == "forced" ]]; then
+          IMPORT_GITHUB="true"
+          echo "Using default import mode (backend explicitly forced to S3 — migration scenario): $IMPORT_GITHUB"
+        elif [[ "$WAS_GITHUB_DEFAULT" == "true" ]]; then
+          IMPORT_GITHUB="true"
+          echo "Using default import mode (public repository — previously used GitHub cache by default): $IMPORT_GITHUB"
+        else
+          IMPORT_GITHUB="false"
+          echo "Using default import mode (private/internal repository — already on S3): $IMPORT_GITHUB"
+        fi
+        echo "::endgroup::"
+
+        {
+          echo "cache-backend=$CACHE_BACKEND"
+          echo "backend-source=$BACKEND_SOURCE"
+          echo "was-github-default=$WAS_GITHUB_DEFAULT"
+          echo "import-github=$IMPORT_GITHUB"
+        } >> "$GITHUB_OUTPUT"
         echo "ACTION_PATH_CACHE=${{ github.action_path }}" >> "$GITHUB_ENV"
 
     - name: Cache with GitHub Actions (public repos)
@@ -143,35 +171,6 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
       run: $ACTION_PATH_CACHE/scripts/prepare-keys.sh
 
-    - name: Determine GitHub cache import mode
-      if: steps.cache-backend.outputs.cache-backend == 's3'
-      id: import-mode
-      shell: bash
-      env:
-        INPUT_IMPORT_GITHUB_CACHE: ${{ inputs.import-github-cache }}
-        BACKEND_SOURCE: ${{ steps.cache-backend.outputs.backend-source }}
-        WAS_GITHUB_DEFAULT: ${{ steps.cache-backend.outputs.was-github-default }}
-      run: |
-        # Resolution order: input → CACHE_IMPORT_GITHUB env var → true if backend was explicitly forced (migration scenario)
-        #                 → true if public repo switching from GitHub default → false (private/internal, already on S3)
-        if [[ -n "$INPUT_IMPORT_GITHUB_CACHE" ]]; then
-          IMPORT_GITHUB="$INPUT_IMPORT_GITHUB_CACHE"
-          echo "Using import mode from input: $IMPORT_GITHUB"
-        elif [[ -n "${CACHE_IMPORT_GITHUB:-}" ]]; then
-          IMPORT_GITHUB="$CACHE_IMPORT_GITHUB"
-          echo "Using import mode from CACHE_IMPORT_GITHUB environment variable: $IMPORT_GITHUB"
-        elif [[ "$BACKEND_SOURCE" == "forced" ]]; then
-          IMPORT_GITHUB="true"
-          echo "Using default import mode (backend explicitly forced to S3 — migration scenario): $IMPORT_GITHUB"
-        elif [[ "$WAS_GITHUB_DEFAULT" == "true" ]]; then
-          IMPORT_GITHUB="true"
-          echo "Using default import mode (public repository — previously used GitHub cache by default): $IMPORT_GITHUB"
-        else
-          IMPORT_GITHUB="false"
-          echo "Using default import mode (private/internal repository — already on S3): $IMPORT_GITHUB"
-        fi
-        echo "import-github=$IMPORT_GITHUB" >> "$GITHUB_OUTPUT"
-
     - name: Cache on S3
       if: steps.cache-backend.outputs.cache-backend == 's3'
       uses: runs-on/cache@50350ad4242587b6c8c2baa2e740b1bc11285ff4 # v4.3.0
@@ -195,14 +194,14 @@ runs:
         enableCrossOsArchive: ${{ inputs.enableCrossOsArchive }}
         # When import mode is active, suppress fail-on-cache-miss here: a subsequent step handles it after also attempting the GitHub cache
         # fallback.
-        fail-on-cache-miss: ${{ steps.import-mode.outputs.import-github == 'true' && 'false' || inputs.fail-on-cache-miss }}
+        fail-on-cache-miss: ${{ steps.cache-backend.outputs.import-github == 'true' && 'false' || inputs.fail-on-cache-miss }}
         lookup-only: ${{ inputs.lookup-only }}
 
     - name: Import GitHub cache to S3 (migration fallback)
       if: >-
         steps.cache-backend.outputs.cache-backend == 's3' &&
         steps.s3-cache.outputs.cache-hit != 'true' &&
-        steps.import-mode.outputs.import-github == 'true'
+        steps.cache-backend.outputs.import-github == 'true'
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: github-import
       with:
@@ -215,7 +214,7 @@ runs:
     - name: Enforce fail-on-cache-miss after GitHub import fallback
       if: >-
         steps.cache-backend.outputs.cache-backend == 's3' &&
-        steps.import-mode.outputs.import-github == 'true' &&
+        steps.cache-backend.outputs.import-github == 'true' &&
         inputs.fail-on-cache-miss == 'true' &&
         steps.s3-cache.outputs.cache-hit != 'true' &&
         steps.github-import.outputs.cache-matched-key == ''
@@ -246,30 +245,45 @@ runs:
         echo "matched-key=${MATCHED_KEY}" >> "$GITHUB_OUTPUT"
 
     # CI_METRICS_ENABLED is set by the runner pod template / WarpBuild AMI for the BUILD-11068 pilot repos.
+    # Restricted to the S3 backend so credential-guard-post (which only runs on S3) can act as the symlink
+    # keeper that recreates `.actions/cache-metrics` if a nested actions/checkout wiped it before the
+    # cache-metrics post step — see test-s3-cache-survives-git-clean-with-metrics.
+    # The symlink-into-the-workspace pattern is the one documented in SonarSource/ci-github-actions
+    # CONTRIBUTE.md (BUILD-9094) — required so this composite can reference its own `cache-metrics` Node20
+    # sub-action via `uses: ./.actions/cache-metrics` from inside container jobs and nested local actions.
     - name: Prepare local cache-metrics sub-action
       id: cache-metrics-prep
-      if: runner.os == 'Linux' && env.CI_METRICS_ENABLED == 'true'
+      if: >-
+        runner.os == 'Linux' && env.CI_METRICS_ENABLED == 'true' &&
+        steps.cache-backend.outputs.cache-backend == 's3'
       shell: bash
       # Fail-open: the metrics flow must never break the cache flow. The next step's `if:` will skip gracefully if preparation fails.
       run: |
+        echo "::group::Prepare .actions/cache-metrics symlink"
         set +e
+        ACTION_PATH_CACHE="${{ github.action_path }}"
+        echo "github.action_path=$ACTION_PATH_CACHE"
         mkdir -p .actions
         ln -sf "$ACTION_PATH_CACHE/cache-metrics" .actions/cache-metrics
+        ls -la .actions/*
         if [ ! -e .actions/cache-metrics/action.yml ]; then
           echo "::warning::cache-metrics: could not prepare .actions/cache-metrics symlink — skipping metrics."
           echo "prepared=false" >> "$GITHUB_OUTPUT"
+          echo "::endgroup::"
           exit 0
         fi
-        # `git add -f` stages the symlink so `git clean -ffdx` (used by actions/checkout with default `clean: true`) does not remove it
-        # between main and post steps.
+        # `git add -f` is best-effort: it survives a bare `git clean -ffdx`, but not the subsequent
+        # `git reset --hard HEAD` + `git checkout --force <ref>` that actions/checkout runs. The real
+        # safety net is credential-guard-post's symlink keeper (see action.yml `Credential guard` step).
         if ! git add -f .actions 2>/dev/null; then
           echo "::warning::cache-metrics: could not 'git add' the .actions symlink."
         fi
         echo "prepared=true" >> "$GITHUB_OUTPUT"
+        echo "::endgroup::"
         exit 0
 
     - name: Emit cache metrics (size + saved)
-      if: runner.os == 'Linux' && steps.cache-metrics-prep.outputs.prepared == 'true'
+      if: steps.cache-metrics-prep.outputs.prepared == 'true'
       id: cache-metrics
       uses: ./.actions/cache-metrics
       with:
@@ -286,6 +300,10 @@ runs:
       uses: SonarSource/gh-action_cache/credential-guard@v1
       with:
         credentials-file: ${{ steps.aws-auth.outputs.credentials-file }}
+        # Pass our action path so credential-guard-post can recreate the workspace symlink to cache-metrics
+        # if a nested actions/checkout (clean → reset --hard → checkout --force) wiped it from the workspace.
+        # Empty when metrics are disabled — the post step is a no-op then.
+        cache-metrics-action-path: ${{ steps.cache-metrics-prep.outputs.prepared == 'true' && format('{0}/cache-metrics', github.action_path) || '' }}
 
 branding:
   icon: upload-cloud

--- a/credential-guard/action.yml
+++ b/credential-guard/action.yml
@@ -4,8 +4,18 @@ inputs:
   credentials-file:
     description: Path to the credentials JSON file
     required: true
+  cache-metrics-action-path:
+    description: >-
+      Absolute path to the `cache-metrics` sub-action directory inside the parent gh-action_cache checkout (typically
+      the parent action's github.action_path joined with `cache-metrics`). When set, the post step recreates the
+      workspace symlink `.actions/cache-metrics` if it has been wiped by a nested actions/checkout
+      `git clean` + `git reset --hard` between the cache-metrics main and post steps. Empty to disable.
+    required: false
+    default: ''
 runs:
   using: node20
   main: dist/main/index.js
+  # Post must run even on prior failure: cache-metrics-post uses `post-if: always()`, so its action.yml needs to be
+  # resolvable on failure too — otherwise the runner emits a hard "Can't find action.yml" error at job end.
   post: dist/post/index.js
-  post-if: success()
+  post-if: always()

--- a/credential-guard/dist/main/index.js
+++ b/credential-guard/dist/main/index.js
@@ -25688,6 +25688,13 @@ async function run() {
     try {
         const credentialsFile = core.getInput('credentials-file', { required: true });
         core.saveState('credentials-file', credentialsFile);
+        // Optional: address path used by the post step to recreate the workspace symlink
+        // `.actions/cache-metrics` if a nested actions/checkout wiped it between cache-metrics
+        // main and post. Empty when CI_METRICS_ENABLED is off or this is a non-Linux run.
+        const cacheMetricsActionPath = core.getInput('cache-metrics-action-path');
+        if (cacheMetricsActionPath) {
+            core.saveState('cache-metrics-action-path', cacheMetricsActionPath);
+        }
         core.info(`Credential guard registered (file: ${credentialsFile})`);
         core.info('Credentials will be restored in post-step before cache save');
     }

--- a/credential-guard/dist/post/index.js
+++ b/credential-guard/dist/post/index.js
@@ -25682,6 +25682,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ensureCacheMetricsSymlink = ensureCacheMetricsSymlink;
 exports.getAwsDir = getAwsDir;
 exports.writeAwsCredentialsFile = writeAwsCredentialsFile;
 exports.run = run;
@@ -25690,6 +25691,49 @@ const fs = __importStar(__nccwpck_require__(1943));
 const os = __importStar(__nccwpck_require__(857));
 const path = __importStar(__nccwpck_require__(6928));
 const AWS_REGION = 'eu-central-1';
+const CACHE_METRICS_WORKSPACE_LINK = path.join('.actions', 'cache-metrics');
+/**
+ * Recreate the `.actions/cache-metrics` symlink if a nested actions/checkout wiped it
+ * between this composite's main steps and cache-metrics' post step. Runs before the
+ * cache-metrics post step (LIFO ordering) so its `uses: ./.actions/cache-metrics`
+ * resolves even after `git clean -ffdx` + `git reset --hard HEAD` +
+ * `git checkout --force <ref>` from a nested actions/checkout in the same job.
+ *
+ * Best-effort: any failure here is logged but never fails the credential-guard post step.
+ */
+async function ensureCacheMetricsSymlink(target) {
+    if (!target)
+        return;
+    try {
+        await fs.access(path.join(CACHE_METRICS_WORKSPACE_LINK, 'action.yml'));
+        return;
+    }
+    catch {
+        // fall through to recreate
+    }
+    try {
+        await fs.access(path.join(target, 'action.yml'));
+    }
+    catch (err) {
+        core.warning(`cache-metrics symlink keeper: target action.yml missing under ${target} — skipping recreation: ${err instanceof Error ? err.message : err}`);
+        return;
+    }
+    try {
+        await fs.mkdir(path.dirname(CACHE_METRICS_WORKSPACE_LINK), { recursive: true });
+        try {
+            await fs.unlink(CACHE_METRICS_WORKSPACE_LINK);
+        }
+        catch {
+            // either doesn't exist (ENOENT) or is a directory (EISDIR) — unlink fails silently;
+            // symlink() will error with EEXIST in that case and the outer catch will log a warning.
+        }
+        await fs.symlink(target, CACHE_METRICS_WORKSPACE_LINK);
+        core.info(`cache-metrics symlink keeper: recreated ${CACHE_METRICS_WORKSPACE_LINK} -> ${target}`);
+    }
+    catch (err) {
+        core.warning(`cache-metrics symlink keeper: failed to recreate ${CACHE_METRICS_WORKSPACE_LINK}: ${err instanceof Error ? err.message : err}`);
+    }
+}
 function getAwsDir() {
     return path.join(process.env.__TEST_AWS_HOME || os.homedir(), '.aws');
 }
@@ -25713,9 +25757,13 @@ async function writeAwsCredentialsFile(creds) {
     core.info('Wrote credentials to ~/.aws/credentials [default] profile (fallback for nested composites)');
 }
 async function run() {
+    // Run the symlink keeper FIRST so cache-metrics' post step (which fires after this one in
+    // the LIFO post phase) can still resolve `./.actions/cache-metrics/action.yml` even when
+    // a nested actions/checkout has wiped the workspace symlink. Best-effort.
+    await ensureCacheMetricsSymlink(core.getState('cache-metrics-action-path'));
     const credentialsFile = core.getState('credentials-file');
     if (!credentialsFile) {
-        core.warning('No credentials file path in state — skipping credential restore');
+        core.info('No credentials file path in state — skipping credential restore');
         return;
     }
     try {

--- a/src/credential-guard-main.ts
+++ b/src/credential-guard-main.ts
@@ -4,6 +4,15 @@ export async function run(): Promise<void> {
   try {
     const credentialsFile = core.getInput('credentials-file', { required: true });
     core.saveState('credentials-file', credentialsFile);
+
+    // Optional: address path used by the post step to recreate the workspace symlink
+    // `.actions/cache-metrics` if a nested actions/checkout wiped it between cache-metrics
+    // main and post. Empty when CI_METRICS_ENABLED is off or this is a non-Linux run.
+    const cacheMetricsActionPath = core.getInput('cache-metrics-action-path');
+    if (cacheMetricsActionPath) {
+      core.saveState('cache-metrics-action-path', cacheMetricsActionPath);
+    }
+
     core.info(`Credential guard registered (file: ${credentialsFile})`);
     core.info('Credentials will be restored in post-step before cache save');
   } catch (error) {

--- a/src/credential-guard-post.ts
+++ b/src/credential-guard-post.ts
@@ -4,6 +4,56 @@ import * as os from 'os';
 import * as path from 'path';
 
 const AWS_REGION = 'eu-central-1';
+const CACHE_METRICS_WORKSPACE_LINK = path.join('.actions', 'cache-metrics');
+
+/**
+ * Recreate the `.actions/cache-metrics` symlink if a nested actions/checkout wiped it
+ * between this composite's main steps and cache-metrics' post step. Runs before the
+ * cache-metrics post step (LIFO ordering) so its `uses: ./.actions/cache-metrics`
+ * resolves even after `git clean -ffdx` + `git reset --hard HEAD` +
+ * `git checkout --force <ref>` from a nested actions/checkout in the same job.
+ *
+ * Best-effort: any failure here is logged but never fails the credential-guard post step.
+ */
+export async function ensureCacheMetricsSymlink(target: string): Promise<void> {
+  if (!target) return;
+
+  try {
+    await fs.access(path.join(CACHE_METRICS_WORKSPACE_LINK, 'action.yml'));
+    return;
+  } catch {
+    // fall through to recreate
+  }
+
+  try {
+    await fs.access(path.join(target, 'action.yml'));
+  } catch (err) {
+    core.warning(
+      `cache-metrics symlink keeper: target action.yml missing under ${target} — skipping recreation: ${
+        err instanceof Error ? err.message : err
+      }`
+    );
+    return;
+  }
+
+  try {
+    await fs.mkdir(path.dirname(CACHE_METRICS_WORKSPACE_LINK), { recursive: true });
+    try {
+      await fs.unlink(CACHE_METRICS_WORKSPACE_LINK);
+    } catch {
+      // either doesn't exist (ENOENT) or is a directory (EISDIR) — unlink fails silently;
+      // symlink() will error with EEXIST in that case and the outer catch will log a warning.
+    }
+    await fs.symlink(target, CACHE_METRICS_WORKSPACE_LINK);
+    core.info(`cache-metrics symlink keeper: recreated ${CACHE_METRICS_WORKSPACE_LINK} -> ${target}`);
+  } catch (err) {
+    core.warning(
+      `cache-metrics symlink keeper: failed to recreate ${CACHE_METRICS_WORKSPACE_LINK}: ${
+        err instanceof Error ? err.message : err
+      }`
+    );
+  }
+}
 
 export function getAwsDir(): string {
   return path.join(process.env.__TEST_AWS_HOME || os.homedir(), '.aws');
@@ -40,9 +90,14 @@ export async function writeAwsCredentialsFile(creds: {
 }
 
 export async function run(): Promise<void> {
+  // Run the symlink keeper FIRST so cache-metrics' post step (which fires after this one in
+  // the LIFO post phase) can still resolve `./.actions/cache-metrics/action.yml` even when
+  // a nested actions/checkout has wiped the workspace symlink. Best-effort.
+  await ensureCacheMetricsSymlink(core.getState('cache-metrics-action-path'));
+
   const credentialsFile = core.getState('credentials-file');
   if (!credentialsFile) {
-    core.warning('No credentials file path in state — skipping credential restore');
+    core.info('No credentials file path in state — skipping credential restore');
     return;
   }
 


### PR DESCRIPTION
## Summary

Fixes two regressions in the `cache-metrics` flow observed in
[SonarSource/sonar-dummy#592 (pre-commit)](https://github.com/SonarSource/sonar-dummy/actions/runs/26102811096/job/76758257880)
and
[SonarSource/sonar-dummy#592 (integration-test container)](https://github.com/SonarSource/sonar-dummy/actions/runs/26102810763/job/76758256477).
Two commits: one functional change (`b7146e4`), one **test-only pin to drop before merge** (`0d7b9b6`).

- **Container self-reference** — applied the
  [`SonarSource/ci-github-actions` CONTRIBUTE.md (BUILD-9094)](https://github.com/SonarSource/ci-github-actions/blob/master/CONTRIBUTE.md#referring-local-actions)
  symlink pattern verbatim in `cache-metrics-prep`: read `${{ github.action_path }}` inside the
  step, run `ls -la .actions/*`. Merged the `Determine GitHub cache import mode` step into
  `Determine cache backend` and wrapped both blocks under `::group::` to collapse the
  step-header noise that prompted the original verbosity complaint.
- **Pre-commit `git clean` regression** — the existing `git add -f .actions` workaround
  survives `git clean -ffdx` but is provably wiped by the `git reset --hard HEAD` +
  `git checkout --force <ref>` pair that `actions/checkout` runs after a clean (verified
  empirically in a scratch repo). `credential-guard-post` now acts as the symlink keeper:
  a new optional `cache-metrics-action-path` input lets it recreate `.actions/cache-metrics`
  before `cache-metrics` post fires in the LIFO post phase. `post-if` bumped from `success()`
  to `always()` so the keeper still runs on the failure path. Metrics flow restricted to the
  S3 backend (credential-guard only runs on S3, so the keeper has no equivalent on the
  GitHub backend — gating keeps the failure mode out of github-backend pipelines too).
- **`[TEST-ONLY]` pin** (`0d7b9b6`) — `credential-guard` pinned to the same-branch SHA
  (`b7146e4`) so this PR's CI exercises the new input before the `v1` branch is moved.
  **Drop this commit before merge.** Once `b7146e4` is on `v1`, restore
  `uses: SonarSource/gh-action_cache/credential-guard@v1` in `action.yml`.

## Test plan

- [x] `test-s3-cache-survives-git-clean-with-metrics` (new) — covers the nested
      `actions/checkout` scenario that wiped the symlink.
- [x] `test-cache-metrics-output` still passes.
- [x] All existing regression tests stay green (`test-s3-cache-survives-git-clean`,
      `test-s3-cache-with-credential-interference`, `test-s3-cache-multiple-invocations`,
      `test-s3-cache-with-preset-aws-config`, `test-s3-cache-windows`).
- [x] Validated end-to-end on sonar-dummy `feat/jcarsique/BUILD-11294-test-cache-metrics`:
      [pre-commit](https://github.com/SonarSource/sonar-dummy/actions/runs/26148262370)
      and [Integration Test (container)](https://github.com/SonarSource/sonar-dummy/actions/runs/26148262365)
      both green. Keeper log on the post phase:
      `cache-metrics symlink keeper: recreated .actions/cache-metrics -> /home/runner/_work/_actions/SonarSource/gh-action_cache/fix/jcarsique/BUILD-11297-container/cache-metrics`
      followed by `cache-metrics: saved size = 407173108 B, saved=false, updated /tmp/ci-metrics/cache-__SonarSource_ci-github-actions.json`.

## Release steps

1. Drop `0d7b9b6` (the `[TEST-ONLY]` pin).
2. Merge `b7146e4` to `master`.
3. Release ASAP
4. Move the `v1` branch to include `b7146e4` so users on `@v1` pick up the symlink keeper.

## What's Next
https://sonarsource.atlassian.net/browse/BUILD-11417