### PR TITLE
BUILD-11295 Gate cache-metrics on layered decision file (workflow env > pre-job file)

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -425,6 +425,115 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
 
+  # File-only path: metrics on when ${CI_METRICS_DIR}/enabled exists, even with no `env.CI_METRICS_ENABLED`.
+  # Simulates a runner whose pre-job hook (github-runners-infra/hooks/job-started.sh) wrote the decision file.
+  test-cache-metrics-via-decision-file:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+      contents: read
+    # No CI_METRICS_ENABLED env on purpose — the gate must enable via the file alone.
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          version: 2025.7.12
+
+      - name: Simulate runner pre-job decision file
+        run: |
+          mkdir -p /tmp/ci-metrics
+          : > /tmp/ci-metrics/enabled
+          ls -la /tmp/ci-metrics
+
+      - name: Cache pip with S3 (file-only gate)
+        id: cache-file-gate
+        uses: ./
+        with:
+          path: ~/.cache/pip
+          key: file-gate-test-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: file-gate-test-${{ runner.os }}-
+          environment: dev
+          backend: s3
+
+      - name: Verify metrics ran (cache-size-bytes output is set)
+        run: |
+          if [[ -z "${{ steps.cache-file-gate.outputs.cache-size-bytes }}" ]]; then
+            echo "::error::cache-size-bytes output was empty — gate did not honour the decision file"
+            exit 1
+          fi
+          echo "cache-size-bytes = ${{ steps.cache-file-gate.outputs.cache-size-bytes }}"
+
+      - name: Verify ${CI_METRICS_DIR}/cache-*.json was written
+        run: |
+          shopt -s nullglob
+          files=(/tmp/ci-metrics/cache-*.json)
+          if (( ${#files[@]} == 0 )); then
+            echo "::error::no cache-*.json under /tmp/ci-metrics/ — file-gate path did not emit metrics"
+            ls -la /tmp/ci-metrics/ || true
+            exit 1
+          fi
+
+      - name: Populate cache path so the post-step measures a saved size
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+  # Workflow opt-out beats the decision file. Pre-touches the file (as the runner pre-job hook would),
+  # then sets CI_METRICS_ENABLED='false' at the job level. Metrics MUST NOT run, no cache-*.json written.
+  test-cache-metrics-workflow-false-beats-file:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CI_METRICS_ENABLED: 'false'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          version: 2025.7.12
+
+      - name: Simulate runner pre-job decision file (will be overridden by workflow env)
+        run: |
+          mkdir -p /tmp/ci-metrics
+          : > /tmp/ci-metrics/enabled
+          ls -la /tmp/ci-metrics
+
+      - name: Cache pip with S3 (workflow opt-out)
+        id: cache-workflow-false
+        uses: ./
+        with:
+          path: ~/.cache/pip
+          key: workflow-false-test-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: workflow-false-test-${{ runner.os }}-
+          environment: dev
+          backend: s3
+
+      - name: Verify metrics did NOT run (cache-size-bytes empty, no cache-*.json)
+        run: |
+          if [[ -n "${{ steps.cache-workflow-false.outputs.cache-size-bytes }}" ]]; then
+            echo "::error::cache-size-bytes was '${{ steps.cache-workflow-false.outputs.cache-size-bytes }}' — workflow CI_METRICS_ENABLED=false did NOT win over the decision file"
+            exit 1
+          fi
+          shopt -s nullglob
+          files=(/tmp/ci-metrics/cache-*.json)
+          if (( ${#files[@]} > 0 )); then
+            echo "::error::cache-*.json files present — workflow CI_METRICS_ENABLED=false did NOT skip the cache-metrics sub-action"
+            ls -la /tmp/ci-metrics/
+            exit 1
+          fi
+          # The propagator step should have removed the pre-existing enabled file.
+          if [[ -e /tmp/ci-metrics/enabled ]]; then
+            echo "::error::/tmp/ci-metrics/enabled still exists — toggle step did not honour CI_METRICS_ENABLED=false"
+            exit 1
+          fi
+          echo "ok: gate correctly disabled via workflow opt-out"
+
+      - name: Populate cache path so the post-step has something to save
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
   all-green:
     name: All Tests
     if: always()
@@ -439,6 +548,8 @@ jobs:
       - test-s3-cache-survives-git-clean
       - test-s3-cache-survives-git-clean-with-metrics
       - test-cache-metrics-output
+      - test-cache-metrics-via-decision-file
+      - test-cache-metrics-workflow-false-beats-file
     runs-on: github-ubuntu-latest-s
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ These must be committed since GitHub Actions runs them directly.
 |-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `CACHE_BACKEND`       | Force specific backend: `github` or `s3` (overrides auto-detection).                                                                                                                                       |
 | `CACHE_IMPORT_GITHUB` | Disable GitHub cache fallback for S3 backend (migration mode) when set to `false`.                                                                                                                         |
-| `CI_METRICS_ENABLED`  | Opt-in feature flag for pipeline runtime metrics (Linux only). Set to `true` to enable emission of the `cache-size-bytes` output and the per-invocation JSON record at `${CI_METRICS_DIR}/cache-*.json`.   |
-| `CI_METRICS_DIR`      | Output directory for the per-invocation metrics JSON (only consulted when `CI_METRICS_ENABLED=true`). Provided by the ARC pod template / WarpBuild AMI; defaults to `/tmp/ci-metrics` when unset or empty. |
+| `CI_METRICS_ENABLED`  | Workflow-level override for the pipeline-runtime-metrics gate (Linux only). `'true'` forces metrics on, `'false'` forces metrics off; unset honours the runner-side decision file (see below).             |
+| `CI_METRICS_DIR`      | Directory holding the runner-side decision file (`enabled`) and the per-invocation cache JSON. Provided by the ARC pod template / WarpBuild AMI; defaults to `/tmp/ci-metrics` when unset or empty.        |
 
 ## Inputs
 
@@ -189,14 +189,26 @@ gh variable set CACHE_IMPORT_GITHUB --body "true"
 
 ### Pipeline runtime metrics
 
-On Linux runners — and only when `CI_METRICS_ENABLED` is set to `true` — the action writes a per-invocation JSON record to
+On Linux runners — and only when the layered gate below resolves to "on" — the action writes a per-invocation JSON record to
 `${CI_METRICS_DIR}/cache-${step}.json` for the [pipeline runtime metrics](https://sonarsource.atlassian.net/browse/BUILD-11068)
 `job-completed.sh` hook to ingest. The output directory is taken from the `CI_METRICS_DIR` environment variable (provided by the
 ARC pod template / WarpBuild AMI); it falls back to `/tmp/ci-metrics` when the variable is unset or empty.
 The record captures both the restore-time size and the pre-save size, plus whether the cache was actually saved.
 
-When `CI_METRICS_ENABLED` is unset or set to anything other than `true`, the cache flow runs exactly as before — no metrics steps, no JSON
-file, and `cache-size-bytes` is empty. The other outputs (`cache-hit`, `cache-matched-key`, `restore-key-hit`, `backend`) are unaffected.
+**Gate resolution** ([BUILD-11295](https://sonarsource.atlassian.net/browse/BUILD-11295)):
+
+1. Workflow `env: { CI_METRICS_ENABLED: 'false' }` → off (beats everything).
+2. Workflow `env: { CI_METRICS_ENABLED: 'true' }` → on (beats the runner-side allow/deny).
+3. Otherwise, on iff `${CI_METRICS_DIR}/enabled` exists. This file is written at job start by the runner pre-job hook
+   (`github-runners-infra/hooks/job-started.sh`) based on the per-env, per-repo, per-workflow allow/deny lists. On runners outside
+   SonarSource's ARC pool (GitHub-hosted, WarpBuild), the file is absent unless a workflow setup step touches it explicitly.
+
+When the gate resolves to "off", the cache flow runs exactly as before — no metrics steps, no JSON file, and `cache-size-bytes`
+is empty. The other outputs (`cache-hit`, `cache-matched-key`, `restore-key-hit`, `backend`) are unaffected.
+
+The action also propagates the workflow `CI_METRICS_ENABLED` override to the same file (touch on `'true'`, remove on `'false'`)
+so the post-job `job-completed.sh` hook sees the same decision the cache action did. Workflows that don't use this action and
+still want to override can add the equivalent 4-line setup step (`case ... touch/rm $CI_METRICS_DIR/enabled`).
 
 **Example — partial restore-key hit (primary missed, prefix-matched older entry restored, then re-saved under primary key):**
 

--- a/action.yml
+++ b/action.yml
@@ -244,17 +244,48 @@ runs:
         echo "cache-hit=${CACHE_HIT}" >> "$GITHUB_OUTPUT"
         echo "matched-key=${MATCHED_KEY}" >> "$GITHUB_OUTPUT"
 
-    # CI_METRICS_ENABLED is set by the runner pod template / WarpBuild AMI for the BUILD-11068 pilot repos.
-    # Restricted to the S3 backend so credential-guard-post (which only runs on S3) can act as the symlink
-    # keeper that recreates `.actions/cache-metrics` if a nested actions/checkout wiped it before the
-    # cache-metrics post step — see test-s3-cache-survives-git-clean-with-metrics.
-    # The symlink-into-the-workspace pattern is the one documented in SonarSource/ci-github-actions
-    # CONTRIBUTE.md (BUILD-9094) — required so this composite can reference its own `cache-metrics` Node20
-    # sub-action via `uses: ./.actions/cache-metrics` from inside container jobs and nested local actions.
+    # CI-metrics gating.
+    # The single source of truth is the presence-only file ${CI_METRICS_DIR}/enabled written by the runner's pre-job hook.
+    # Workflow-level `env: { CI_METRICS_ENABLED: 'true'|'false' }` always wins.
+    # The step also mutates the file in the workflow-env override cases so the runner's post-job hook follows.
+    - name: Resolve CI metrics gate
+      id: ci-metrics-gate
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "::group::CI metrics gate"
+        CI_METRICS_DIR="${CI_METRICS_DIR:-/tmp/ci-metrics}"
+        case "${CI_METRICS_ENABLED:-}" in
+          true)
+            mkdir -p "$CI_METRICS_DIR"
+            : > "$CI_METRICS_DIR/enabled"
+            decision=true
+            reason="Metrics enabled: workflow-env-true (touched $CI_METRICS_DIR/enabled for post-job hook)"
+            ;;
+          false)
+            rm -f "$CI_METRICS_DIR/enabled"
+            decision=false
+            reason="Metrics disabled: workflow-env-false (removed $CI_METRICS_DIR/enabled)"
+            ;;
+          *)
+            if [[ -e "$CI_METRICS_DIR/enabled" ]]; then
+                decision=true
+                reason="Metrics enabled: runner-side decision file present at $CI_METRICS_DIR/enabled"
+            else
+                decision=false
+                reason="Metrics disabled: no signal (CI_METRICS_ENABLED unset and $CI_METRICS_DIR/enabled absent)"
+            fi
+            ;;
+        esac
+        echo "$reason"
+        echo "decision=$decision" >> "$GITHUB_OUTPUT"
+        echo "::endgroup::"
+
+    # S3 restriction: credential-guard only runs on S3 and embeds the symlink keeper (BUILD-11417)
     - name: Prepare local cache-metrics sub-action
       id: cache-metrics-prep
       if: >-
-        runner.os == 'Linux' && env.CI_METRICS_ENABLED == 'true' &&
+        steps.ci-metrics-gate.outputs.decision == 'true' &&
         steps.cache-backend.outputs.cache-backend == 's3'
       shell: bash
       # Fail-open: the metrics flow must never break the cache flow. The next step's `if:` will skip gracefully if preparation fails.


### PR DESCRIPTION
## Summary

Replaces the simple `env.CI_METRICS_ENABLED == 'true'` gate on the `cache-metrics-prep` step with a layered check that honours both the workflow-level env override AND a presence-only decision file `${CI_METRICS_DIR}/enabled` written by the runner pre-job hook (in `github-runners-infra`, see Validation chain below).

**Resolution** (a new early step `Resolve CI metrics gate` does this in bash, then exposes the result as `steps.ci-metrics-gate.outputs.decision`):

- workflow `env.CI_METRICS_ENABLED == 'false'` → off (beats everything) — also `rm -f` the decision file so the post-job hook agrees
- workflow `env.CI_METRICS_ENABLED == 'true'`  → on  (beats the allow/deny lists) — also `touch` the decision file
- otherwise on iff `${CI_METRICS_DIR}/enabled` exists at job-start

**New gate** (one expression on `Prepare local cache-metrics sub-action`):

```yaml
if: >-
  steps.ci-metrics-gate.outputs.decision == 'true' &&
  steps.cache-backend.outputs.cache-backend == 's3'
```

We resolve in bash rather than splitting workflow-env vs. file-presence between a `case` step and a GHA `if:` expression because GHA's `hashFiles()` only accepts paths under `$GITHUB_WORKSPACE` — it returns empty for `/tmp/ci-metrics/enabled`. Resolving in shell and emitting a step output keeps the gate one-shot and correct on every path.

## Validation chain

- end-to-end validator (TEST, DO NOT MERGE): https://github.com/SonarSource/sonar-dummy/pull/592
  - transitive pin (TEST, DO NOT MERGE): https://github.com/SonarSource/ci-github-actions/pull/267
  - cache-action gate: https://github.com/SonarSource/gh-action_cache/pull/71 — this PR
  - runner pre-job hook (deployed with `deploy-dev` label): https://github.com/SonarSource/github-runners-infra/pull/410

## Test plan

- [x] YAML lint + `actionlint` pass.
- [x] `test-cache-metrics-via-decision-file` (new) — file-only path, no env override. Pre-touches `${CI_METRICS_DIR}/enabled`, verifies cache-metrics emit fires.
- [x] `test-cache-metrics-workflow-false-beats-file` (new) — env=`false` beats pre-touched file; verifies the propagator `rm -f`'d the file and metrics did NOT emit.
- [x] Existing env=`true` tests (`test-cache-metrics-output`, `test-s3-cache-survives-git-clean-with-metrics`) — still pass under the new gate.
- [x] All 26 CI checks green.
- [x] End-to-end validation through SonarSource/sonar-dummy#592 → SonarSource/ci-github-actions#267 → this PR, on `sonar-dev` runners — all checks green.

## Links

- Jira: https://sonarsource.atlassian.net/browse/BUILD-11295
- Design comment: https://sonarsource.atlassian.net/browse/BUILD-11295?focusedCommentId=919695