### PR TITLE
BUILD-11417 Extract symlink keeper into its own sub-action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ credential-guard/dist/**/*.d.ts
 credential-guard/dist/**/*.d.ts.map
 cache-metrics/dist/**/*.d.ts
 cache-metrics/dist/**/*.d.ts.map
+symlink-keeper/dist/**/*.d.ts
+symlink-keeper/dist/**/*.d.ts.map
 
 # Test coverage
 coverage/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,11 @@ repos:
     hooks:
       # ncc-bundled sub-actions live in <sub-action>/dist/ and we don't control their formatting.
       - id: trailing-whitespace
-        exclude: ^(credential-setup/dist/|credential-guard/dist/|cache-metrics/dist/)
+        exclude: ^(credential-setup/dist/|credential-guard/dist/|cache-metrics/dist/|symlink-keeper/dist/)
       - id: end-of-file-fixer
-        exclude: ^(credential-setup/dist/|credential-guard/dist/|cache-metrics/dist/)
+        exclude: ^(credential-setup/dist/|credential-guard/dist/|cache-metrics/dist/|symlink-keeper/dist/)
       - id: check-added-large-files
-        exclude: ^(credential-setup/dist/|credential-guard/dist/|cache-metrics/dist/)
+        exclude: ^(credential-setup/dist/|credential-guard/dist/|cache-metrics/dist/|symlink-keeper/dist/)
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.48.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -35,17 +35,21 @@ npm run test:watch    # watch mode
 
 ### Build
 
-The JS sub-actions (`credential-setup`, `credential-guard`) are bundled with
+The JS sub-actions (`credential-setup`, `credential-guard`, `cache-metrics`, `symlink-keeper`) are bundled with
 `@vercel/ncc` into self-contained dist files. Rebuild after changing TypeScript source:
 
 ```bash
-npm run build         # build all sub-actions
-npm run build:setup   # build credential-setup only
-npm run build:guard-main  # build credential-guard main only
-npm run build:guard-post  # build credential-guard post only
+npm run build               # build all sub-actions
+npm run build:setup         # build credential-setup only
+npm run build:guard-main    # build credential-guard main only
+npm run build:guard-post    # build credential-guard post only
+npm run build:metrics-main  # build cache-metrics main only
+npm run build:metrics-post  # build cache-metrics post only
+npm run build:keeper-main   # build symlink-keeper main only
+npm run build:keeper-post   # build symlink-keeper post only
 ```
 
-Bundled output goes to `credential-setup/dist/` and `credential-guard/dist/`.
+Bundled output goes to `credential-setup/dist/`, `credential-guard/dist/`, `cache-metrics/dist/`, and `symlink-keeper/dist/`.
 These must be committed since GitHub Actions runs them directly.
 
 ## Usage

--- a/__tests__/credential-guard.test.ts
+++ b/__tests__/credential-guard.test.ts
@@ -35,33 +35,6 @@ describe('credential-guard-main', () => {
     );
   });
 
-  it('saves cache-metrics-action-path to GITHUB_STATE when provided', async () => {
-    const credsPath = path.join(os.tmpdir(), 'creds', 'credentials.json');
-    const metricsPath = path.join(os.tmpdir(), 'action', 'cache-metrics');
-    const inputs: Record<string, string> = {
-      'credentials-file': credsPath,
-      'cache-metrics-action-path': metricsPath,
-    };
-    vi.mocked(core.getInput).mockImplementation((name: string) => inputs[name] ?? '');
-
-    const { run } = await import('../src/credential-guard-main');
-    await run();
-
-    expect(core.saveState).toHaveBeenCalledWith('cache-metrics-action-path', metricsPath);
-  });
-
-  it('does not save cache-metrics-action-path state when input is empty', async () => {
-    const inputs: Record<string, string> = {
-      'credentials-file': path.join(os.tmpdir(), 'creds.json'),
-    };
-    vi.mocked(core.getInput).mockImplementation((name: string) => inputs[name] ?? '');
-
-    const { run } = await import('../src/credential-guard-main');
-    await run();
-
-    expect(core.saveState).not.toHaveBeenCalledWith('cache-metrics-action-path', expect.anything());
-  });
-
   it('fails when credentials-file input is missing', async () => {
     vi.mocked(core.getInput).mockImplementation(() => {
       throw new Error('Input required and not supplied: credentials-file');
@@ -126,16 +99,13 @@ describe('credential-guard-post', () => {
     expect(core.exportVariable).not.toHaveBeenCalled();
   });
 
-  it('logs and exits cleanly when no state was saved', async () => {
-    // Demoted from warning to info: credential-guard-post now also handles the cache-metrics
-    // symlink keeper, so an empty credentials-file is the normal no-op path on non-S3 runs.
+  it('warns if no state was saved', async () => {
     vi.mocked(core.getState).mockReturnValue('');
 
     const { run } = await import('../src/credential-guard-post');
     await run();
 
-    expect(core.info).toHaveBeenCalledWith(expect.stringContaining('No credentials file'));
-    expect(core.exportVariable).not.toHaveBeenCalled();
+    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('No credentials file'));
   });
 
   it('writes ~/.aws/credentials with correct INI format', async () => {
@@ -231,85 +201,6 @@ describe('credential-guard-post', () => {
     expect(core.info).toHaveBeenCalledWith(
       'Wrote credentials to ~/.aws/credentials [default] profile (fallback for nested composites)'
     );
-  });
-
-  it('symlink keeper: skips when target is empty (CI_METRICS_ENABLED unset)', async () => {
-    vi.mocked(core.getState).mockReturnValue('');
-
-    const { ensureCacheMetricsSymlink } = await import('../src/credential-guard-post');
-    await ensureCacheMetricsSymlink('');
-
-    expect(core.warning).not.toHaveBeenCalled();
-    expect(core.info).not.toHaveBeenCalled();
-  });
-
-  it('symlink keeper: leaves existing symlink alone when target action.yml is reachable', async () => {
-    // Layout: <tmp>/source/cache-metrics/action.yml is the canonical target.
-    //         <tmp>/workspace/.actions/cache-metrics is an existing symlink to it.
-    const source = path.join(tmpDir, 'source', 'cache-metrics');
-    await fs.mkdir(source, { recursive: true });
-    await fs.writeFile(path.join(source, 'action.yml'), 'name: dummy\n');
-    const workspace = path.join(tmpDir, 'workspace');
-    await fs.mkdir(path.join(workspace, '.actions'), { recursive: true });
-    await fs.symlink(source, path.join(workspace, '.actions', 'cache-metrics'));
-
-    const prevCwd = process.cwd();
-    process.chdir(workspace);
-    try {
-      const { ensureCacheMetricsSymlink } = await import('../src/credential-guard-post');
-      await ensureCacheMetricsSymlink(source);
-    } finally {
-      process.chdir(prevCwd);
-    }
-
-    // No recreation log fired — the existing symlink was left untouched.
-    expect(core.info).not.toHaveBeenCalledWith(expect.stringContaining('recreated'));
-    // Sanity: still a symlink pointing at source.
-    const linkTarget = await fs.readlink(path.join(workspace, '.actions', 'cache-metrics'));
-    expect(linkTarget).toBe(source);
-  });
-
-  it('symlink keeper: recreates the symlink when missing', async () => {
-    const source = path.join(tmpDir, 'source', 'cache-metrics');
-    await fs.mkdir(source, { recursive: true });
-    await fs.writeFile(path.join(source, 'action.yml'), 'name: dummy\n');
-    const workspace = path.join(tmpDir, 'workspace');
-    await fs.mkdir(workspace, { recursive: true });
-
-    const prevCwd = process.cwd();
-    process.chdir(workspace);
-    try {
-      const { ensureCacheMetricsSymlink } = await import('../src/credential-guard-post');
-      await ensureCacheMetricsSymlink(source);
-    } finally {
-      process.chdir(prevCwd);
-    }
-
-    const linkTarget = await fs.readlink(path.join(workspace, '.actions', 'cache-metrics'));
-    expect(linkTarget).toBe(source);
-    expect(core.info).toHaveBeenCalledWith(expect.stringContaining('recreated'));
-  });
-
-  it('symlink keeper: warns and skips when target action.yml is missing', async () => {
-    const missingSource = path.join(tmpDir, 'no-such-source', 'cache-metrics');
-    const workspace = path.join(tmpDir, 'workspace');
-    await fs.mkdir(workspace, { recursive: true });
-
-    const prevCwd = process.cwd();
-    process.chdir(workspace);
-    try {
-      const { ensureCacheMetricsSymlink } = await import('../src/credential-guard-post');
-      await ensureCacheMetricsSymlink(missingSource);
-    } finally {
-      process.chdir(prevCwd);
-    }
-
-    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('target action.yml missing'));
-    const linkExists = await fs
-      .access(path.join(workspace, '.actions', 'cache-metrics'))
-      .then(() => true)
-      .catch(() => false);
-    expect(linkExists).toBe(false);
   });
 
   it('does not write ~/.aws/credentials when credentials are missing fields', async () => {

--- a/__tests__/symlink-keeper.test.ts
+++ b/__tests__/symlink-keeper.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+vi.mock('@actions/core', () => ({
+  getInput: vi.fn(),
+  saveState: vi.fn(),
+  getState: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+}));
+
+import * as core from '@actions/core';
+
+describe('symlink-keeper-main', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('saves cache-metrics-action-path to GITHUB_STATE when provided', async () => {
+    const metricsPath = path.join(os.tmpdir(), 'action', 'cache-metrics');
+    vi.mocked(core.getInput).mockReturnValue(metricsPath);
+
+    const { run } = await import('../src/symlink-keeper-main');
+    await run();
+
+    expect(core.saveState).toHaveBeenCalledWith('cache-metrics-action-path', metricsPath);
+  });
+
+  it('does not save state when input is empty', async () => {
+    vi.mocked(core.getInput).mockReturnValue('');
+
+    const { run } = await import('../src/symlink-keeper-main');
+    await run();
+
+    expect(core.saveState).not.toHaveBeenCalled();
+  });
+});
+
+describe('symlink-keeper-post', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'keeper-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('skips when target is empty (CI_METRICS_ENABLED unset)', async () => {
+    const { ensureCacheMetricsSymlink } = await import('../src/symlink-keeper-post');
+    await ensureCacheMetricsSymlink('');
+
+    expect(core.warning).not.toHaveBeenCalled();
+    expect(core.info).not.toHaveBeenCalled();
+  });
+
+  it('leaves existing symlink alone when target action.yml is reachable', async () => {
+    // Layout: <tmp>/source/cache-metrics/action.yml is the canonical target.
+    //         <tmp>/workspace/.actions/cache-metrics is an existing symlink to it.
+    const source = path.join(tmpDir, 'source', 'cache-metrics');
+    await fs.mkdir(source, { recursive: true });
+    await fs.writeFile(path.join(source, 'action.yml'), 'name: dummy\n');
+    const workspace = path.join(tmpDir, 'workspace');
+    await fs.mkdir(path.join(workspace, '.actions'), { recursive: true });
+    await fs.symlink(source, path.join(workspace, '.actions', 'cache-metrics'));
+
+    const prevCwd = process.cwd();
+    process.chdir(workspace);
+    try {
+      const { ensureCacheMetricsSymlink } = await import('../src/symlink-keeper-post');
+      await ensureCacheMetricsSymlink(source);
+    } finally {
+      process.chdir(prevCwd);
+    }
+
+    // No recreation log fired — the existing symlink was left untouched.
+    expect(core.info).not.toHaveBeenCalledWith(expect.stringContaining('recreated'));
+    // Sanity: still a symlink pointing at source.
+    const linkTarget = await fs.readlink(path.join(workspace, '.actions', 'cache-metrics'));
+    expect(linkTarget).toBe(source);
+  });
+
+  it('recreates the symlink when missing', async () => {
+    const source = path.join(tmpDir, 'source', 'cache-metrics');
+    await fs.mkdir(source, { recursive: true });
+    await fs.writeFile(path.join(source, 'action.yml'), 'name: dummy\n');
+    const workspace = path.join(tmpDir, 'workspace');
+    await fs.mkdir(workspace, { recursive: true });
+
+    const prevCwd = process.cwd();
+    process.chdir(workspace);
+    try {
+      const { ensureCacheMetricsSymlink } = await import('../src/symlink-keeper-post');
+      await ensureCacheMetricsSymlink(source);
+    } finally {
+      process.chdir(prevCwd);
+    }
+
+    const linkTarget = await fs.readlink(path.join(workspace, '.actions', 'cache-metrics'));
+    expect(linkTarget).toBe(source);
+    expect(core.info).toHaveBeenCalledWith(expect.stringContaining('recreated'));
+  });
+
+  it('warns and skips when target action.yml is missing', async () => {
+    const missingSource = path.join(tmpDir, 'no-such-source', 'cache-metrics');
+    const workspace = path.join(tmpDir, 'workspace');
+    await fs.mkdir(workspace, { recursive: true });
+
+    const prevCwd = process.cwd();
+    process.chdir(workspace);
+    try {
+      const { ensureCacheMetricsSymlink } = await import('../src/symlink-keeper-post');
+      await ensureCacheMetricsSymlink(missingSource);
+    } finally {
+      process.chdir(prevCwd);
+    }
+
+    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('target action.yml missing'));
+    const linkExists = await fs
+      .access(path.join(workspace, '.actions', 'cache-metrics'))
+      .then(() => true)
+      .catch(() => false);
+    expect(linkExists).toBe(false);
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -281,12 +281,9 @@ runs:
         echo "decision=$decision" >> "$GITHUB_OUTPUT"
         echo "::endgroup::"
 
-    # S3 restriction: credential-guard only runs on S3 and embeds the symlink keeper (BUILD-11417)
     - name: Prepare local cache-metrics sub-action
       id: cache-metrics-prep
-      if: >-
-        steps.ci-metrics-gate.outputs.decision == 'true' &&
-        steps.cache-backend.outputs.cache-backend == 's3'
+      if: steps.ci-metrics-gate.outputs.decision == 'true'
       shell: bash
       # Fail-open: the metrics flow must never break the cache flow. The next step's `if:` will skip gracefully if preparation fails.
       run: |
@@ -305,7 +302,7 @@ runs:
         fi
         # `git add -f` is best-effort: it survives a bare `git clean -ffdx`, but not the subsequent
         # `git reset --hard HEAD` + `git checkout --force <ref>` that actions/checkout runs. The real
-        # safety net is credential-guard-post's symlink keeper (see action.yml `Credential guard` step).
+        # safety net is the `symlink-keeper` step registered last in this composite.
         if ! git add -f .actions 2>/dev/null; then
           echo "::warning::cache-metrics: could not 'git add' the .actions symlink."
         fi
@@ -331,10 +328,15 @@ runs:
       uses: SonarSource/gh-action_cache/credential-guard@v1
       with:
         credentials-file: ${{ steps.aws-auth.outputs.credentials-file }}
-        # Pass our action path so credential-guard-post can recreate the workspace symlink to cache-metrics
-        # if a nested actions/checkout (clean → reset --hard → checkout --force) wiped it from the workspace.
-        # Empty when metrics are disabled — the post step is a no-op then.
-        cache-metrics-action-path: ${{ steps.cache-metrics-prep.outputs.prepared == 'true' && format('{0}/cache-metrics', github.action_path) || '' }}
+
+    # Must be the LAST main step so its post fires FIRST in the LIFO post phase: it recreates `.actions/cache-metrics` before
+    # cache-metrics-post resolves `uses: ./.actions/cache-metrics`, surviving destruction by an external action between cache-metrics-main
+    # and cache-metrics-post.
+    - name: Symlink keeper (preserve .actions/cache-metrics across nested checkouts)
+      if: steps.cache-metrics-prep.outputs.prepared == 'true'
+      uses: SonarSource/gh-action_cache/symlink-keeper@symlink-keeper-1.0.0
+      with:
+        cache-metrics-action-path: ${{ format('{0}/cache-metrics', github.action_path) }}
 
 branding:
   icon: upload-cloud

--- a/credential-guard/action.yml
+++ b/credential-guard/action.yml
@@ -4,18 +4,8 @@ inputs:
   credentials-file:
     description: Path to the credentials JSON file
     required: true
-  cache-metrics-action-path:
-    description: >-
-      Absolute path to the `cache-metrics` sub-action directory inside the parent gh-action_cache checkout (typically
-      the parent action's github.action_path joined with `cache-metrics`). When set, the post step recreates the
-      workspace symlink `.actions/cache-metrics` if it has been wiped by a nested actions/checkout
-      `git clean` + `git reset --hard` between the cache-metrics main and post steps. Empty to disable.
-    required: false
-    default: ''
 runs:
   using: node20
   main: dist/main/index.js
-  # Post must run even on prior failure: cache-metrics-post uses `post-if: always()`, so its action.yml needs to be
-  # resolvable on failure too — otherwise the runner emits a hard "Can't find action.yml" error at job end.
   post: dist/post/index.js
-  post-if: always()
+  post-if: success()

--- a/credential-guard/dist/main/index.js
+++ b/credential-guard/dist/main/index.js
@@ -31070,13 +31070,6 @@ async function run() {
     try {
         const credentialsFile = core.getInput('credentials-file', { required: true });
         core.saveState('credentials-file', credentialsFile);
-        // Optional: address path used by the post step to recreate the workspace symlink
-        // `.actions/cache-metrics` if a nested actions/checkout wiped it between cache-metrics
-        // main and post. Empty when CI_METRICS_ENABLED is off or this is a non-Linux run.
-        const cacheMetricsActionPath = core.getInput('cache-metrics-action-path');
-        if (cacheMetricsActionPath) {
-            core.saveState('cache-metrics-action-path', cacheMetricsActionPath);
-        }
         core.info(`Credential guard registered (file: ${credentialsFile})`);
         core.info('Credentials will be restored in post-step before cache save');
     }

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "description": "S3 Cache action with credential isolation",
   "scripts": {
-    "build": "npm run build:setup && npm run build:guard-main && npm run build:guard-post && npm run build:metrics-main && npm run build:metrics-post",
+    "build": "npm run build:setup && npm run build:guard-main && npm run build:guard-post && npm run build:metrics-main && npm run build:metrics-post && npm run build:keeper-main && npm run build:keeper-post",
     "build:setup": "ncc build src/credential-setup.ts -o credential-setup/dist --license licenses.txt",
     "build:guard-main": "ncc build src/credential-guard-main.ts -o credential-guard/dist/main --license licenses.txt",
     "build:guard-post": "ncc build src/credential-guard-post.ts -o credential-guard/dist/post --license licenses.txt",
     "build:metrics-main": "ncc build src/cache-metrics-main.ts -o cache-metrics/dist/main --license licenses.txt",
     "build:metrics-post": "ncc build src/cache-metrics-post.ts -o cache-metrics/dist/post --license licenses.txt",
+    "build:keeper-main": "ncc build src/symlink-keeper-main.ts -o symlink-keeper/dist/main --license licenses.txt",
+    "build:keeper-post": "ncc build src/symlink-keeper-post.ts -o symlink-keeper/dist/post --license licenses.txt",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/credential-guard-main.ts
+++ b/src/credential-guard-main.ts
@@ -4,15 +4,6 @@ export async function run(): Promise<void> {
   try {
     const credentialsFile = core.getInput('credentials-file', { required: true });
     core.saveState('credentials-file', credentialsFile);
-
-    // Optional: address path used by the post step to recreate the workspace symlink
-    // `.actions/cache-metrics` if a nested actions/checkout wiped it between cache-metrics
-    // main and post. Empty when CI_METRICS_ENABLED is off or this is a non-Linux run.
-    const cacheMetricsActionPath = core.getInput('cache-metrics-action-path');
-    if (cacheMetricsActionPath) {
-      core.saveState('cache-metrics-action-path', cacheMetricsActionPath);
-    }
-
     core.info(`Credential guard registered (file: ${credentialsFile})`);
     core.info('Credentials will be restored in post-step before cache save');
   } catch (error) {

--- a/src/credential-guard-post.ts
+++ b/src/credential-guard-post.ts
@@ -4,56 +4,6 @@ import * as os from 'os';
 import * as path from 'path';
 
 const AWS_REGION = 'eu-central-1';
-const CACHE_METRICS_WORKSPACE_LINK = path.join('.actions', 'cache-metrics');
-
-/**
- * Recreate the `.actions/cache-metrics` symlink if a nested actions/checkout wiped it
- * between this composite's main steps and cache-metrics' post step. Runs before the
- * cache-metrics post step (LIFO ordering) so its `uses: ./.actions/cache-metrics`
- * resolves even after `git clean -ffdx` + `git reset --hard HEAD` +
- * `git checkout --force <ref>` from a nested actions/checkout in the same job.
- *
- * Best-effort: any failure here is logged but never fails the credential-guard post step.
- */
-export async function ensureCacheMetricsSymlink(target: string): Promise<void> {
-  if (!target) return;
-
-  try {
-    await fs.access(path.join(CACHE_METRICS_WORKSPACE_LINK, 'action.yml'));
-    return;
-  } catch {
-    // fall through to recreate
-  }
-
-  try {
-    await fs.access(path.join(target, 'action.yml'));
-  } catch (err) {
-    core.warning(
-      `cache-metrics symlink keeper: target action.yml missing under ${target} — skipping recreation: ${
-        err instanceof Error ? err.message : err
-      }`
-    );
-    return;
-  }
-
-  try {
-    await fs.mkdir(path.dirname(CACHE_METRICS_WORKSPACE_LINK), { recursive: true });
-    try {
-      await fs.unlink(CACHE_METRICS_WORKSPACE_LINK);
-    } catch {
-      // either doesn't exist (ENOENT) or is a directory (EISDIR) — unlink fails silently;
-      // symlink() will error with EEXIST in that case and the outer catch will log a warning.
-    }
-    await fs.symlink(target, CACHE_METRICS_WORKSPACE_LINK);
-    core.info(`cache-metrics symlink keeper: recreated ${CACHE_METRICS_WORKSPACE_LINK} -> ${target}`);
-  } catch (err) {
-    core.warning(
-      `cache-metrics symlink keeper: failed to recreate ${CACHE_METRICS_WORKSPACE_LINK}: ${
-        err instanceof Error ? err.message : err
-      }`
-    );
-  }
-}
 
 export function getAwsDir(): string {
   return path.join(process.env.__TEST_AWS_HOME || os.homedir(), '.aws');
@@ -90,14 +40,9 @@ export async function writeAwsCredentialsFile(creds: {
 }
 
 export async function run(): Promise<void> {
-  // Run the symlink keeper FIRST so cache-metrics' post step (which fires after this one in
-  // the LIFO post phase) can still resolve `./.actions/cache-metrics/action.yml` even when
-  // a nested actions/checkout has wiped the workspace symlink. Best-effort.
-  await ensureCacheMetricsSymlink(core.getState('cache-metrics-action-path'));
-
   const credentialsFile = core.getState('credentials-file');
   if (!credentialsFile) {
-    core.info('No credentials file path in state — skipping credential restore');
+    core.warning('No credentials file path in state — skipping credential restore');
     return;
   }
 

--- a/src/symlink-keeper-main.ts
+++ b/src/symlink-keeper-main.ts
@@ -1,0 +1,14 @@
+import * as core from '@actions/core';
+
+export async function run(): Promise<void> {
+  const cacheMetricsActionPath = core.getInput('cache-metrics-action-path');
+  if (cacheMetricsActionPath) {
+    core.saveState('cache-metrics-action-path', cacheMetricsActionPath);
+  }
+  core.info(`Symlink keeper registered (cache-metrics-action-path: ${cacheMetricsActionPath || '<empty>'})`);
+}
+
+/* istanbul ignore next */
+if (!process.env.VITEST) {
+  run();
+}

--- a/src/symlink-keeper-post.ts
+++ b/src/symlink-keeper-post.ts
@@ -1,0 +1,63 @@
+import * as core from '@actions/core';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+const CACHE_METRICS_WORKSPACE_LINK = path.join('.actions', 'cache-metrics');
+
+/**
+ * Recreate the `.actions/cache-metrics` symlink if a nested actions/checkout wiped it
+ * between the parent composite's main steps and cache-metrics' post step. Runs before the
+ * cache-metrics post step (LIFO ordering) so its `uses: ./.actions/cache-metrics`
+ * resolves even after `git clean -ffdx` + `git reset --hard HEAD` +
+ * `git checkout --force <ref>` from a nested actions/checkout in the same job.
+ *
+ * Best-effort: any failure here is logged but never fails the post step.
+ */
+export async function ensureCacheMetricsSymlink(target: string): Promise<void> {
+  if (!target) return;
+
+  try {
+    await fs.access(path.join(CACHE_METRICS_WORKSPACE_LINK, 'action.yml'));
+    return;
+  } catch {
+    // fall through to recreate
+  }
+
+  try {
+    await fs.access(path.join(target, 'action.yml'));
+  } catch (err) {
+    core.warning(
+      `cache-metrics symlink keeper: target action.yml missing under ${target} — skipping recreation: ${
+        err instanceof Error ? err.message : err
+      }`
+    );
+    return;
+  }
+
+  try {
+    await fs.mkdir(path.dirname(CACHE_METRICS_WORKSPACE_LINK), { recursive: true });
+    try {
+      await fs.unlink(CACHE_METRICS_WORKSPACE_LINK);
+    } catch {
+      // either doesn't exist (ENOENT) or is a directory (EISDIR) — unlink fails silently;
+      // symlink() will error with EEXIST in that case and the outer catch will log a warning.
+    }
+    await fs.symlink(target, CACHE_METRICS_WORKSPACE_LINK);
+    core.info(`cache-metrics symlink keeper: recreated ${CACHE_METRICS_WORKSPACE_LINK} -> ${target}`);
+  } catch (err) {
+    core.warning(
+      `cache-metrics symlink keeper: failed to recreate ${CACHE_METRICS_WORKSPACE_LINK}: ${
+        err instanceof Error ? err.message : err
+      }`
+    );
+  }
+}
+
+export async function run(): Promise<void> {
+  await ensureCacheMetricsSymlink(core.getState('cache-metrics-action-path'));
+}
+
+/* istanbul ignore next */
+if (!process.env.VITEST) {
+  run();
+}

--- a/symlink-keeper/action.yml
+++ b/symlink-keeper/action.yml
@@ -1,0 +1,19 @@
+name: Symlink Keeper
+description: >-
+  Internal action - recreates the `.actions/cache-metrics` workspace symlink if a nested actions/checkout wiped it between the parent
+  composite's main phase and the cache-metrics post step.
+inputs:
+  cache-metrics-action-path:
+    description: >-
+      Absolute path to the parent action's `cache-metrics` sub-action directory (typically the parent action's github.action_path joined
+      with `cache-metrics`). When set, the post step recreates the workspace symlink `.actions/cache-metrics` if it has been wiped by a
+      nested actions/checkout `git clean -ffdx` and/or `git reset --hard` between the cache-metrics main and post steps. Empty to disable.
+    required: false
+    default: ''
+runs:
+  using: node20
+  main: dist/main/index.js
+  # Post must run even on prior failure: cache-metrics-post uses `post-if: always()`, so this keeper's post must also run on failure paths
+  # to recreate the symlink before cache-metrics-post fires.
+  post: dist/post/index.js
+  post-if: always()

--- a/symlink-keeper/dist/main/index.js
+++ b/symlink-keeper/dist/main/index.js
@@ -31025,7 +31025,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1321:
+/***/ 6057:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -31064,71 +31064,14 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getAwsDir = getAwsDir;
-exports.writeAwsCredentialsFile = writeAwsCredentialsFile;
 exports.run = run;
 const core = __importStar(__nccwpck_require__(7484));
-const fs = __importStar(__nccwpck_require__(1943));
-const os = __importStar(__nccwpck_require__(857));
-const path = __importStar(__nccwpck_require__(6928));
-const AWS_REGION = 'eu-central-1';
-function getAwsDir() {
-    return path.join(process.env.__TEST_AWS_HOME || os.homedir(), '.aws');
-}
-async function writeAwsCredentialsFile(creds) {
-    const awsDir = getAwsDir();
-    await fs.mkdir(awsDir, { recursive: true, mode: 0o700 });
-    const credentialsContent = [
-        '[default]',
-        `aws_access_key_id = ${creds.AccessKeyId}`,
-        `aws_secret_access_key = ${creds.SecretAccessKey}`,
-        `aws_session_token = ${creds.SessionToken}`,
-        '',
-    ].join('\n');
-    const configContent = ['[default]', `region = ${AWS_REGION}`, ''].join('\n');
-    await fs.writeFile(path.join(awsDir, 'credentials'), credentialsContent, {
-        mode: 0o600,
-    });
-    await fs.writeFile(path.join(awsDir, 'config'), configContent, {
-        mode: 0o600,
-    });
-    core.info('Wrote credentials to ~/.aws/credentials [default] profile (fallback for nested composites)');
-}
 async function run() {
-    const credentialsFile = core.getState('credentials-file');
-    if (!credentialsFile) {
-        core.warning('No credentials file path in state — skipping credential restore');
-        return;
+    const cacheMetricsActionPath = core.getInput('cache-metrics-action-path');
+    if (cacheMetricsActionPath) {
+        core.saveState('cache-metrics-action-path', cacheMetricsActionPath);
     }
-    try {
-        const content = await fs.readFile(credentialsFile, 'utf-8');
-        const creds = JSON.parse(content);
-        // Defensive: re-mask credentials in case setSecret scope changes
-        if (creds.AccessKeyId)
-            core.setSecret(creds.AccessKeyId);
-        if (creds.SecretAccessKey)
-            core.setSecret(creds.SecretAccessKey);
-        if (creds.SessionToken)
-            core.setSecret(creds.SessionToken);
-        if (!creds.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
-            core.warning('Credentials file is missing required fields — skipping');
-            return;
-        }
-        core.exportVariable('AWS_ACCESS_KEY_ID', creds.AccessKeyId);
-        core.exportVariable('AWS_SECRET_ACCESS_KEY', creds.SecretAccessKey);
-        core.exportVariable('AWS_SESSION_TOKEN', creds.SessionToken);
-        core.exportVariable('AWS_REGION', AWS_REGION);
-        core.exportVariable('AWS_DEFAULT_REGION', AWS_REGION);
-        // Clear profile-based config so AWS SDK uses fromEnv() instead of fromIni().
-        // Safe here because this is a post step — no user code runs after it.
-        core.exportVariable('AWS_PROFILE', '');
-        core.exportVariable('AWS_DEFAULT_PROFILE', '');
-        await writeAwsCredentialsFile(creds);
-        core.info('Cache credentials restored for post-step cache save');
-    }
-    catch (error) {
-        core.warning(`Failed to restore credentials: ${error instanceof Error ? error.message : error}`);
-    }
+    core.info(`Symlink keeper registered (cache-metrics-action-path: ${cacheMetricsActionPath || '<empty>'})`);
 }
 /* istanbul ignore next */
 if (!process.env.VITEST) {
@@ -31175,14 +31118,6 @@ module.exports = require("events");
 
 "use strict";
 module.exports = require("fs");
-
-/***/ }),
-
-/***/ 1943:
-/***/ ((module) => {
-
-"use strict";
-module.exports = require("fs/promises");
 
 /***/ }),
 
@@ -31460,7 +31395,7 @@ module.exports = require("util");
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(1321);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(6057);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/symlink-keeper/dist/main/licenses.txt
+++ b/symlink-keeper/dist/main/licenses.txt
@@ -1,0 +1,109 @@
+@actions/core
+MIT
+The MIT License (MIT)
+
+Copyright 2019 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@actions/exec
+MIT
+The MIT License (MIT)
+
+Copyright 2019 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@actions/http-client
+MIT
+Actions Http Client for Node.js
+
+Copyright (c) GitHub, Inc.
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+@actions/io
+MIT
+The MIT License (MIT)
+
+Copyright 2019 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+tunnel
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2012 Koichi Kobayashi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+undici
+MIT
+MIT License
+
+Copyright (c) Matteo Collina and Undici contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/symlink-keeper/dist/post/index.js
+++ b/symlink-keeper/dist/post/index.js
@@ -31025,7 +31025,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1321:
+/***/ 2830:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -31064,71 +31064,56 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getAwsDir = getAwsDir;
-exports.writeAwsCredentialsFile = writeAwsCredentialsFile;
+exports.ensureCacheMetricsSymlink = ensureCacheMetricsSymlink;
 exports.run = run;
 const core = __importStar(__nccwpck_require__(7484));
-const fs = __importStar(__nccwpck_require__(1943));
-const os = __importStar(__nccwpck_require__(857));
-const path = __importStar(__nccwpck_require__(6928));
-const AWS_REGION = 'eu-central-1';
-function getAwsDir() {
-    return path.join(process.env.__TEST_AWS_HOME || os.homedir(), '.aws');
-}
-async function writeAwsCredentialsFile(creds) {
-    const awsDir = getAwsDir();
-    await fs.mkdir(awsDir, { recursive: true, mode: 0o700 });
-    const credentialsContent = [
-        '[default]',
-        `aws_access_key_id = ${creds.AccessKeyId}`,
-        `aws_secret_access_key = ${creds.SecretAccessKey}`,
-        `aws_session_token = ${creds.SessionToken}`,
-        '',
-    ].join('\n');
-    const configContent = ['[default]', `region = ${AWS_REGION}`, ''].join('\n');
-    await fs.writeFile(path.join(awsDir, 'credentials'), credentialsContent, {
-        mode: 0o600,
-    });
-    await fs.writeFile(path.join(awsDir, 'config'), configContent, {
-        mode: 0o600,
-    });
-    core.info('Wrote credentials to ~/.aws/credentials [default] profile (fallback for nested composites)');
-}
-async function run() {
-    const credentialsFile = core.getState('credentials-file');
-    if (!credentialsFile) {
-        core.warning('No credentials file path in state — skipping credential restore');
+const fs = __importStar(__nccwpck_require__(1455));
+const path = __importStar(__nccwpck_require__(6760));
+const CACHE_METRICS_WORKSPACE_LINK = path.join('.actions', 'cache-metrics');
+/**
+ * Recreate the `.actions/cache-metrics` symlink if a nested actions/checkout wiped it
+ * between the parent composite's main steps and cache-metrics' post step. Runs before the
+ * cache-metrics post step (LIFO ordering) so its `uses: ./.actions/cache-metrics`
+ * resolves even after `git clean -ffdx` + `git reset --hard HEAD` +
+ * `git checkout --force <ref>` from a nested actions/checkout in the same job.
+ *
+ * Best-effort: any failure here is logged but never fails the post step.
+ */
+async function ensureCacheMetricsSymlink(target) {
+    if (!target)
+        return;
+    try {
+        await fs.access(path.join(CACHE_METRICS_WORKSPACE_LINK, 'action.yml'));
+        return;
+    }
+    catch {
+        // fall through to recreate
+    }
+    try {
+        await fs.access(path.join(target, 'action.yml'));
+    }
+    catch (err) {
+        core.warning(`cache-metrics symlink keeper: target action.yml missing under ${target} — skipping recreation: ${err instanceof Error ? err.message : err}`);
         return;
     }
     try {
-        const content = await fs.readFile(credentialsFile, 'utf-8');
-        const creds = JSON.parse(content);
-        // Defensive: re-mask credentials in case setSecret scope changes
-        if (creds.AccessKeyId)
-            core.setSecret(creds.AccessKeyId);
-        if (creds.SecretAccessKey)
-            core.setSecret(creds.SecretAccessKey);
-        if (creds.SessionToken)
-            core.setSecret(creds.SessionToken);
-        if (!creds.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
-            core.warning('Credentials file is missing required fields — skipping');
-            return;
+        await fs.mkdir(path.dirname(CACHE_METRICS_WORKSPACE_LINK), { recursive: true });
+        try {
+            await fs.unlink(CACHE_METRICS_WORKSPACE_LINK);
         }
-        core.exportVariable('AWS_ACCESS_KEY_ID', creds.AccessKeyId);
-        core.exportVariable('AWS_SECRET_ACCESS_KEY', creds.SecretAccessKey);
-        core.exportVariable('AWS_SESSION_TOKEN', creds.SessionToken);
-        core.exportVariable('AWS_REGION', AWS_REGION);
-        core.exportVariable('AWS_DEFAULT_REGION', AWS_REGION);
-        // Clear profile-based config so AWS SDK uses fromEnv() instead of fromIni().
-        // Safe here because this is a post step — no user code runs after it.
-        core.exportVariable('AWS_PROFILE', '');
-        core.exportVariable('AWS_DEFAULT_PROFILE', '');
-        await writeAwsCredentialsFile(creds);
-        core.info('Cache credentials restored for post-step cache save');
+        catch {
+            // either doesn't exist (ENOENT) or is a directory (EISDIR) — unlink fails silently;
+            // symlink() will error with EEXIST in that case and the outer catch will log a warning.
+        }
+        await fs.symlink(target, CACHE_METRICS_WORKSPACE_LINK);
+        core.info(`cache-metrics symlink keeper: recreated ${CACHE_METRICS_WORKSPACE_LINK} -> ${target}`);
     }
-    catch (error) {
-        core.warning(`Failed to restore credentials: ${error instanceof Error ? error.message : error}`);
+    catch (err) {
+        core.warning(`cache-metrics symlink keeper: failed to recreate ${CACHE_METRICS_WORKSPACE_LINK}: ${err instanceof Error ? err.message : err}`);
     }
+}
+async function run() {
+    await ensureCacheMetricsSymlink(core.getState('cache-metrics-action-path'));
 }
 /* istanbul ignore next */
 if (!process.env.VITEST) {
@@ -31175,14 +31160,6 @@ module.exports = require("events");
 
 "use strict";
 module.exports = require("fs");
-
-/***/ }),
-
-/***/ 1943:
-/***/ ((module) => {
-
-"use strict";
-module.exports = require("fs/promises");
 
 /***/ }),
 
@@ -31274,6 +31251,14 @@ module.exports = require("node:events");
 
 /***/ }),
 
+/***/ 1455:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("node:fs/promises");
+
+/***/ }),
+
 /***/ 7067:
 /***/ ((module) => {
 
@@ -31295,6 +31280,14 @@ module.exports = require("node:http2");
 
 "use strict";
 module.exports = require("node:net");
+
+/***/ }),
+
+/***/ 6760:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("node:path");
 
 /***/ }),
 
@@ -31460,7 +31453,7 @@ module.exports = require("util");
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(1321);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(2830);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/symlink-keeper/dist/post/licenses.txt
+++ b/symlink-keeper/dist/post/licenses.txt
@@ -1,0 +1,109 @@
+@actions/core
+MIT
+The MIT License (MIT)
+
+Copyright 2019 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@actions/exec
+MIT
+The MIT License (MIT)
+
+Copyright 2019 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@actions/http-client
+MIT
+Actions Http Client for Node.js
+
+Copyright (c) GitHub, Inc.
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+@actions/io
+MIT
+The MIT License (MIT)
+
+Copyright 2019 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+tunnel
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2012 Koichi Kobayashi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+undici
+MIT
+MIT License
+
+Copyright (c) Matteo Collina and Undici contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Moves `ensureCacheMetricsSymlink` out of `credential-guard-post` into a new `symlink-keeper/` sub-action; `credential-setup`/`credential-guard` revert to their pre-keeper baseline.
- Registers the new step as the LAST main step of the top-level composite so its post fires FIRST in the LIFO post phase, recreating `.actions/cache-metrics` before `cache-metrics-post` resolves `uses: ./.actions/cache-metrics`.
- Drops the temporary `cache-backend == 's3'` gate from `cache-metrics-prep` — metrics can now opt-in via `CI_METRICS_ENABLED` on both backends.

## Ref strategy

`action.yml` references `SonarSource/gh-action_cache/symlink-keeper@symlink-keeper-1.0.0`. The branch [`symlink-keeper-1.0.0`](https://github.com/SonarSource/gh-action_cache/tree/symlink-keeper-1.0.0) is pinned at this PR's commit so CI on the PR can resolve the ref. After merge to master, the branch is replaced by a tag of the same name on the same commit (independent of the main `v1.x.y` cadence).

## Test plan

- [x] `npm test` — all 54 unit tests pass (6 keeper tests now under `__tests__/symlink-keeper.test.ts`; credential-guard tests slimmed to credential-restore only).
- [x] `npm run build` — produces the new `symlink-keeper/dist/{main,post}/index.js` bundles and the rebuilt `credential-guard/dist/{main,post}/index.js`.
- [x] `pre-commit run --all-files` — clean.
- [ ] In-repo regression: `test-s3-cache-survives-git-clean-with-metrics` (`.github/workflows/test-action.yml`) green on this PR — proves `symlink-keeper-post` recreates `.actions/cache-metrics` before `cache-metrics-post` fires after a nested `actions/checkout`.
- [ ] Other regressions green: `test-s3-cache-with-credential-interference`, `test-s3-cache-windows`, `test-s3-cache-multiple-invocations`, `test-s3-cache-with-preset-aws-config`, `test-s3-cache-survives-git-clean` — proves the credential-guard revert didn't regress credential restore.
- [ ] End-to-end through https://github.com/SonarSource/ci-github-actions/pull/267 → https://github.com/SonarSource/sonar-dummy/pull/592 (both re-pinned to this branch).

## Links

- Jira: https://sonarsource.atlassian.net/browse/BUILD-11417
- Parent epic: https://sonarsource.atlassian.net/browse/BUILD-11068