### PR TITLE
BUILD-11417 Drop redundant `git add -f .actions` from cache-metrics-prep

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -361,7 +361,7 @@ jobs:
 
       # Simulate what a nested actions/checkout does (clean → reset --hard → fetch → checkout --force).
       # This is the sequence that wiped `.actions/cache-metrics` from the workspace between main and post
-      # in the pre-commit job — the `git add -f .actions` workaround survives the clean but not the reset.
+      # in the pre-commit job — recovery is handled by the `symlink-keeper` post step.
       - name: Re-run actions/checkout (simulates nested action's checkout)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/action.yml
+++ b/action.yml
@@ -300,12 +300,6 @@ runs:
           echo "::endgroup::"
           exit 0
         fi
-        # `git add -f` is best-effort: it survives a bare `git clean -ffdx`, but not the subsequent
-        # `git reset --hard HEAD` + `git checkout --force <ref>` that actions/checkout runs. The real
-        # safety net is the `symlink-keeper` step registered last in this composite.
-        if ! git add -f .actions 2>/dev/null; then
-          echo "::warning::cache-metrics: could not 'git add' the .actions symlink."
-        fi
         echo "prepared=true" >> "$GITHUB_OUTPUT"
         echo "::endgroup::"
         exit 0


### PR DESCRIPTION
## Summary
- Remove the `git add -f .actions` block from the `cache-metrics-prep` step in `action.yml`. It was originally a workaround to survive a bare `git clean -ffdx` between cache-metrics main and post — superseded by the [`symlink-keeper`](https://github.com/SonarSource/gh-action_cache/blob/master/symlink-keeper/action.yml) post step (added in 0414458, BUILD-11417).
- Side effect now removed: staging the symlink leaked it into downstream `git commit -a` runs (Renovate, release bots), causing `.actions/cache-metrics` to appear as a tracked change in consumer PRs — observed in [SonarSource/re-observability#303](https://github.com/SonarSource/re-observability/pull/303).
- Updated the matching comment in `test-cache-metrics-survives-git-clean` to credit `symlink-keeper` instead of the removed workaround.

YAML-only change. No `src/` touched, no bundle rebuild needed.

## Test plan
- [ ] `test-cache-metrics-survives-git-clean` still passes (simulates the `clean → reset --hard → checkout --force` sequence; symlink-keeper post is the safety net).
- [ ] `test-s3-cache-survives-git-clean` and the other regression jobs continue to pass.
- [ ] Confirm in a downstream consumer that `.actions/cache-metrics` no longer appears in `git status` after the cache step.