### PR TITLE
BUILD-10781 Migrate sub-actions to Node 24 and bump pinned actions to v5

### DIFF
--- a/.github/workflows/check-cache-migration.yml
+++ b/.github/workflows/check-cache-migration.yml
@@ -23,7 +23,7 @@ jobs:
       actions: write  # required to list GitHub cache entries and set the opt-out repository variable
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup S3 cache credentials
         id: aws-auth

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -35,7 +35,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cleanup cache
         uses: ./cleanup

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -13,8 +13,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
         version: 2025.7.12
     - name: Cache Python dependencies
@@ -46,8 +46,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
       - name: Cache Python dependencies
@@ -81,8 +81,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
         version: 2025.7.12
     - name: Cache Go modules with fallback branch
@@ -127,8 +127,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
 
@@ -171,7 +171,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cache with S3 on Windows
         id: cache-test
@@ -195,8 +195,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
 
@@ -237,8 +237,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
 
@@ -306,8 +306,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
 
@@ -344,8 +344,8 @@ jobs:
     env:
       CI_METRICS_ENABLED: 'true'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
 
@@ -363,7 +363,7 @@ jobs:
       # This is the sequence that wiped `.actions/cache-metrics` from the workspace between main and post
       # in the pre-commit job — recovery is handled by the `symlink-keeper` post step.
       - name: Re-run actions/checkout (simulates nested action's checkout)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create something to cache
         run: |
@@ -382,8 +382,8 @@ jobs:
       # Opt-in to the metrics emission
       CI_METRICS_ENABLED: 'true'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
 
@@ -434,8 +434,8 @@ jobs:
       contents: read
     # No CI_METRICS_ENABLED env on purpose — the gate must enable via the file alone.
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
 
@@ -488,8 +488,8 @@ jobs:
     env:
       CI_METRICS_ENABLED: 'false'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
 

--- a/.github/workflows/test-cache-migration-gh2s3.yml
+++ b/.github/workflows/test-cache-migration-gh2s3.yml
@@ -15,16 +15,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Save GitHub cache entry (for import scenario)
         run: mkdir -p ~/.cache/test-migration && echo "github-content" > ~/.cache/test-migration/test-file.txt
-      - uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/test-migration
           key: test-migration-gh
       - name: Save GitHub cache entry (for S3-hit scenario, to confirm it is NOT restored)
         run: echo "github-content" > ~/.cache/test-migration/test-file.txt
-      - uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/test-migration
           key: test-migration-s3hit
@@ -37,7 +37,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create S3 cache content
         run: mkdir -p ~/.cache/test-migration && echo "s3-content" > ~/.cache/test-migration/test-file.txt
       - name: Save to S3 cache
@@ -58,7 +58,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cache with migration fallback
         id: cache
         uses: ./
@@ -83,7 +83,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cache without migration fallback
         id: cache
         uses: ./
@@ -109,7 +109,7 @@ jobs:
     env:
       CACHE_IMPORT_GITHUB: 'false'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cache without migration fallback (via env)
         id: cache
         uses: ./
@@ -132,7 +132,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cache (S3 hit expected, import enabled)
         id: cache
         uses: ./
@@ -158,7 +158,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cache (auto-detected backend, no backend input or CACHE_BACKEND env)
         id: cache
         uses: ./

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ the matching job:
 
 ## Pinned environment
 
-- Node 20 runtime in both sub-actions (`runs.using: node20`).
+- Node 24 runtime in all four sub-actions (`runs.using: node24`).
 - `python 3.13.5` and `go 1.21.13` in `.tool-versions` — used by the test workflows via `mise`.
 - AWS region hard-coded to `eu-central-1`; S3 bucket pattern `sonarsource-s3-cache-{env}-bucket`.
 - Cognito pool & account IDs for `prod`/`dev` are hard-coded in `src/credential-setup.ts:7-15`.

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
 
     - name: Cache with GitHub Actions (public repos)
       if: steps.cache-backend.outputs.cache-backend == 'github'
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: github-cache
       with:
         path: ${{ inputs.path }}
@@ -173,7 +173,7 @@ runs:
 
     - name: Cache on S3
       if: steps.cache-backend.outputs.cache-backend == 's3'
-      uses: runs-on/cache@50350ad4242587b6c8c2baa2e740b1bc11285ff4 # v4.3.0
+      uses: runs-on/cache@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
       id: s3-cache
       env:
         RUNS_ON_S3_BUCKET_CACHE: sonarsource-s3-cache-${{ inputs.environment }}-bucket
@@ -202,7 +202,7 @@ runs:
         steps.cache-backend.outputs.cache-backend == 's3' &&
         steps.s3-cache.outputs.cache-hit != 'true' &&
         steps.cache-backend.outputs.import-github == 'true'
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: github-import
       with:
         path: ${{ inputs.path }}

--- a/cache-metrics/action.yml
+++ b/cache-metrics/action.yml
@@ -29,7 +29,7 @@ outputs:
   cache-size-bytes:
     description: Total size in bytes of the cached path(s) at restore-time
 runs:
-  using: node20
+  using: node24
   main: dist/main/index.js
   post: dist/post/index.js
   # Run the post step even when an earlier step in the job failed — metrics are most useful precisely when something went wrong, and the

--- a/credential-guard/action.yml
+++ b/credential-guard/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: Path to the credentials JSON file
     required: true
 runs:
-  using: node20
+  using: node24
   main: dist/main/index.js
   post: dist/post/index.js
   post-if: success()

--- a/credential-setup/action.yml
+++ b/credential-setup/action.yml
@@ -14,5 +14,5 @@ outputs:
   AWS_SESSION_TOKEN:
     description: AWS session token
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/symlink-keeper/action.yml
+++ b/symlink-keeper/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: ''
 runs:
-  using: node20
+  using: node24
   main: dist/main/index.js
   # Post must run even on prior failure: cache-metrics-post uses `post-if: always()`, so this keeper's post must also run on failure paths
   # to recreate the symlink before cache-metrics-post fires.


### PR DESCRIPTION
## Why

GitHub deprecates Node 20 on Actions runners starting **2026-06-02** (full removal by Fall 2026). The four JavaScript sub-actions in this repo (`credential-setup`, `credential-guard`, `cache-metrics`, `symlink-keeper`) all declare `using: node20` and will start failing.

The ticket originally proposed a `node20 → node22 → node24` migration, but GitHub Actions metadata does not support `using: node22` (only `node12`/`node16`/`node20`/`node24` are valid — GitHub skipped Node 22 for the action runtime). See [actions/runner#3600](https://github.com/actions/runner/issues/3600). So this PR jumps straight to `node24`.

Linked ticket: [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781).

## What changed

- **4 sub-actions** → `using: node24`:
  - `credential-setup/action.yml`, `credential-guard/action.yml`, `cache-metrics/action.yml`, `symlink-keeper/action.yml`
- **Top-level `action.yml`** — pinned-action bumps:
  - `actions/cache` v4.3.0 → **v5.0.5** (3 refs: `actions/cache@…`, `actions/cache/restore@…`, on the GitHub-cache + migration-fallback paths)
  - `runs-on/cache` v4.3.0 → **v5.0.7** (S3 cache path)
- **Test workflows** (`.github/workflows/*.yml`) — companion bumps required for the test matrix to stay green on Node 24 runners:
  - `actions/checkout` v4.2.2 / v5.0.0 → **v6.0.2**
  - `jdx/mise-action` v2.4.4 → **v4.0.1**
  - `actions/cache/save` v4.3.0 → **v5.0.5**
- **`CLAUDE.md`** — updated the "Pinned environment" note to reflect Node 24 across all four sub-actions.

## What did NOT change

- TypeScript source under `src/` — already Node 22+ compatible (target `ES2022`, `@types/node` ^25).
- `package.json` / `package-lock.json` — no dependency changes.
- The seven committed `dist/*/index.js` ncc bundles — rebuilt locally and byte-identical (the runtime declaration change is metadata-only).

## Supersedes

Closes #58 — that Renovate PR did the same third-party action bumps; rolling them into this PR keeps the runtime migration and dep bump together so the regression suite exercises the full change in one go.

## Verification

Local:
- `npm test` — 54/54 passing.
- `npm run build` — all seven bundles regenerate cleanly; diff is empty (no source change).
- `actionlint` + `markdownlint` clean via pre-commit.

CI on this PR exercises the full credential / cache flow on Node 24 runners via the existing regression jobs in `test-action.yml` and `test-cache-migration-gh2s3.yml`:
- `test-s3-cache` (Linux + Windows)
- `test-s3-cache-with-credential-interference`
- `test-s3-cache-multiple-invocations`
- `test-s3-cache-with-preset-aws-config`
- `test-s3-cache-survives-git-clean`
- `test-cache-migration-gh2s3` matrix
- `test-credential-isolation`

A green run on all of the above is the green light to merge.

## Downstream follow-ups (out of scope here)

- Bump the pinned `gh-action_cache@v1.5.0` SHA in the 8 `ci-github-actions` composite actions once a new release tag is cut.
- Other shared-action repos with their own Node 20 exposure (vault-action-wrapper, jfrog-setup-wrapper, slack-notify, jira-create, unified-dogfooding-actions) — separate tickets.


[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ