### PR TITLE
BUILD-10781 Refresh internal Sonar wrapper pins to Node 24-ready versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,7 @@ jobs:
     name: "pre-commit"
     runs-on: github-ubuntu-latest-s
     steps:
-      - uses: SonarSource/gh-action_pre-commit@fc9d73025994fd1c2b96d568c8c8a4af82a3ae21 # 1.0.6
+      - uses: SonarSource/gh-action_pre-commit@2ddc0c7fdabce0adfaaa4075a17690972ed9961a # 1.2.0
         with:
           extra-args: >
             --from-ref=origin/${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/test-credential-isolation.yml
+++ b/.github/workflows/test-credential-isolation.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Vault
         id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # 3.2.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-sonar-dummy-workflows token | GITHUB_TOKEN;


### PR DESCRIPTION
## Why

Audit of `master` after the BUILD-10781 cascade turned up two stale Sonar-wrapper pins in the internal workflows:

- `.github/workflows/test-credential-isolation.yml` pinned `SonarSource/vault-action-wrapper@3.2.0` — that release internally uses `github-script@v7` + `vault-action@v3` (both Node 20). After GitHub's 2026-06-02 enforcement, this test workflow would emit deprecation warnings and eventually fail.
- `.github/workflows/pre-commit.yml` pinned `SonarSource/gh-action_pre-commit@1.0.6` — the 1.0.6 composite pulls in stale internal pins; 1.2.0 has been current for several months.

The action itself (`action.yml` + the four sub-actions) was already clean.

Linked ticket: [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781).

## What changed

- `SonarSource/vault-action-wrapper@545e7cfb # 3.2.0` → `@0a3114fe # 3.5.0`.
- `SonarSource/gh-action_pre-commit@fc9d7302 # 1.0.6` → `@2ddc0c7f # 1.2.0`.

Two single-line bumps. Diff: 2 files, 2 insertions, 2 deletions.

## Verification

- `pre-commit` clean.
- The test workflow (`test-credential-isolation`) and `pre-commit` workflow themselves will exercise the new pins on this PR.


[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ