### PR TITLE
BUILD-11444 Restore decision-file CI-metrics gate; fix opt-out and hook tests

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -425,27 +425,34 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
 
-  # File-only path: metrics on when ${CI_METRICS_DIR}/enabled exists, even with no `env.CI_METRICS_ENABLED`.
-  # Simulates a runner whose pre-job hook (github-runners-infra/hooks/job-started.sh) wrote the decision file.
-  test-cache-metrics-via-decision-file:
-    runs-on: github-ubuntu-latest-s
+  # Runner-hook path: metrics on when the runner pre-job hook (job-started.sh) writes the decision
+  # file /tmp/ci-metrics/enabled. No workflow-level CI_METRICS_ENABLED — the gate resolves purely
+  # from the presence-only file written by the hook.
+  test-cache-metrics-runner-hook:
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
-    # No CI_METRICS_ENABLED env on purpose — the gate must enable via the file alone.
+    # No CI_METRICS_ENABLED env set here — the runner pre-job hook writes the decision file.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
 
-      - name: Simulate runner pre-job decision file
+      - name: Verify runner pre-job hook activated CI metrics
         run: |
-          mkdir -p /tmp/ci-metrics
-          : > /tmp/ci-metrics/enabled
-          ls -la /tmp/ci-metrics
+          CI_METRICS_DIR="${CI_METRICS_DIR:-/tmp/ci-metrics}"
+          if [[ -e "$CI_METRICS_DIR/enabled" ]]; then
+            echo "Decision file present at $CI_METRICS_DIR/enabled ✓"
+          elif [[ -n "${CI_METRICS_ENABLED:-}" ]]; then
+            echo "CI_METRICS_ENABLED=${CI_METRICS_ENABLED} (hook using GITHUB_ENV approach) ✓"
+          else
+            echo "::error::Neither decision file ($CI_METRICS_DIR/enabled) nor CI_METRICS_ENABLED found — runner pre-job hook not active. Ensure the hook is deployed to this runner pool."
+            exit 1
+          fi
 
-      - name: Cache pip with S3 (file-only gate)
+      - name: Cache pip with S3 (runner hook gate)
         id: cache-file-gate
         uses: ./
         with:
@@ -458,7 +465,7 @@ jobs:
       - name: Verify metrics ran (cache-size-bytes output is set)
         run: |
           if [[ -z "${{ steps.cache-file-gate.outputs.cache-size-bytes }}" ]]; then
-            echo "::error::cache-size-bytes output was empty — gate did not honour the decision file"
+            echo "::error::cache-size-bytes output was empty — runner pre-job hook gate did not activate metrics"
             exit 1
           fi
           echo "cache-size-bytes = ${{ steps.cache-file-gate.outputs.cache-size-bytes }}"
@@ -468,7 +475,7 @@ jobs:
           shopt -s nullglob
           files=(/tmp/ci-metrics/cache-*.json)
           if (( ${#files[@]} == 0 )); then
-            echo "::error::no cache-*.json under /tmp/ci-metrics/ — file-gate path did not emit metrics"
+            echo "::error::no cache-*.json under /tmp/ci-metrics/ — runner hook gate path did not emit metrics"
             ls -la /tmp/ci-metrics/ || true
             exit 1
           fi
@@ -478,9 +485,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
 
-  # Workflow opt-out beats the decision file. Pre-touches the file (as the runner pre-job hook would),
-  # then sets CI_METRICS_ENABLED='false' at the job level. Metrics MUST NOT run, no cache-*.json written.
-  test-cache-metrics-workflow-false-beats-file:
+  # Workflow opt-out beats runner-hook file: simulates the runner pre-job hook writing the decision
+  # file, then verifies that job-level CI_METRICS_ENABLED=false wins (workflow-false > file-present
+  # in the layered gate). The gate step removes the file so the post-job hook also skips metrics.
+  test-cache-metrics-workflow-false:
     runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
@@ -509,25 +517,24 @@ jobs:
           environment: dev
           backend: s3
 
-      - name: Verify metrics did NOT run (cache-size-bytes empty, no cache-*.json)
+      - name: Verify metrics did NOT run (cache-size-bytes empty, no cache-*.json, file removed)
         run: |
           if [[ -n "${{ steps.cache-workflow-false.outputs.cache-size-bytes }}" ]]; then
-            echo "::error::cache-size-bytes was '${{ steps.cache-workflow-false.outputs.cache-size-bytes }}' — workflow CI_METRICS_ENABLED=false did NOT win over the decision file"
+            echo "::error::cache-size-bytes was '${{ steps.cache-workflow-false.outputs.cache-size-bytes }}' — job-level CI_METRICS_ENABLED=false did not disable metrics"
             exit 1
           fi
           shopt -s nullglob
           files=(/tmp/ci-metrics/cache-*.json)
           if (( ${#files[@]} > 0 )); then
-            echo "::error::cache-*.json files present — workflow CI_METRICS_ENABLED=false did NOT skip the cache-metrics sub-action"
+            echo "::error::cache-*.json files present — job-level CI_METRICS_ENABLED=false did NOT skip the cache-metrics sub-action"
             ls -la /tmp/ci-metrics/
             exit 1
           fi
-          # The propagator step should have removed the pre-existing enabled file.
           if [[ -e /tmp/ci-metrics/enabled ]]; then
-            echo "::error::/tmp/ci-metrics/enabled still exists — toggle step did not honour CI_METRICS_ENABLED=false"
+            echo "::error::/tmp/ci-metrics/enabled still exists — gate step did not honour CI_METRICS_ENABLED=false (file should be removed so the post-job hook also skips)"
             exit 1
           fi
-          echo "ok: gate correctly disabled via workflow opt-out"
+          echo "ok: gate correctly disabled via workflow opt-out (decision file absent)"
 
       - name: Populate cache path so the post-step has something to save
         run: |
@@ -548,8 +555,8 @@ jobs:
       - test-s3-cache-survives-git-clean
       - test-s3-cache-survives-git-clean-with-metrics
       - test-cache-metrics-output
-      - test-cache-metrics-via-decision-file
-      - test-cache-metrics-workflow-false-beats-file
+      - test-cache-metrics-runner-hook
+      - test-cache-metrics-workflow-false
     runs-on: github-ubuntu-latest-s
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ cache interface.
 
 ### Input Environment Variables
 
-| Environment Variable  | Description                                                                                                                                                                                                |
-|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `CACHE_BACKEND`       | Force specific backend: `github` or `s3` (overrides auto-detection).                                                                                                                                       |
-| `CACHE_IMPORT_GITHUB` | Disable GitHub cache fallback for S3 backend (migration mode) when set to `false`.                                                                                                                         |
-| `CI_METRICS_ENABLED`  | Workflow-level override for the pipeline-runtime-metrics gate (Linux only). `'true'` forces metrics on, `'false'` forces metrics off; unset honours the runner-side decision file (see below).             |
-| `CI_METRICS_DIR`      | Directory holding the runner-side decision file (`enabled`) and the per-invocation cache JSON. Provided by the ARC pod template / WarpBuild AMI; defaults to `/tmp/ci-metrics` when unset or empty.        |
+| Environment Variable  | Description                                                                                                                                                                   |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `CACHE_BACKEND`       | Force specific backend: `github` or `s3` (overrides auto-detection).                                                                                                          |
+| `CACHE_IMPORT_GITHUB` | Disable GitHub cache fallback for S3 backend (migration mode) when set to `false`.                                                                                            |
+| `CI_METRICS_ENABLED`  | Pipeline-runtime-metrics gate (Linux only). `'true'` → on; `'false'` → off. Without an explicit workflow `env:` override, falls back to `${CI_METRICS_DIR}/enabled` presence. |
+| `CI_METRICS_DIR`      | Holds the runner-side decision file (`enabled`) and per-invocation `cache-*.json` files. Defaults to `/tmp/ci-metrics`; set by ARC pod template or WarpBuild AMI.             |
 
 ### Inputs
 
@@ -162,20 +162,17 @@ The record is written on all platforms once the gate resolves to "on" (see Gate 
 Size fields (`size_bytes_restored`, `size_bytes_at_end`) are `null` on non-Linux (no GNU `du`);
 all other fields (`cache_hit`, `restore_key_hit`, `backend`, `saved`, timestamps, `key`) are populated on every platform.
 
-**Gate resolution** ([BUILD-11295](https://sonarsource.atlassian.net/browse/BUILD-11295)):
+**Gate resolution**:
 
-1. Workflow `env: { CI_METRICS_ENABLED: 'false' }` → off (beats everything).
-2. Workflow `env: { CI_METRICS_ENABLED: 'true' }` → on (beats the runner-side allow/deny).
-3. Otherwise, on iff `${CI_METRICS_DIR}/enabled` exists. This file is written at job start by the runner pre-job hook
-   (`github-runners-infra/hooks/job-started.sh`) based on the per-env, per-repo, per-workflow allow/deny lists. On runners outside
-   SonarSource's ARC pool (GitHub-hosted, WarpBuild), the file is absent unless a workflow setup step touches it explicitly.
+The gate evaluates the workflow-level `env:` block first, then falls back to the presence-only file written by the runner pre-job hook:
 
-When the gate resolves to "off", the cache flow runs exactly as before — no metrics steps, no JSON file, and `cache-size-bytes`
-is empty. The other outputs (`cache-hit`, `cache-matched-key`, `restore-key-hit`, `backend`) are unaffected.
+1. Workflow `env: { CI_METRICS_ENABLED: 'false' }` → off (beats everything; removes `${CI_METRICS_DIR}/enabled` too).
+2. Workflow `env: { CI_METRICS_ENABLED: 'true' }` → on (beats the runner-side decision; touches `${CI_METRICS_DIR}/enabled` too).
+3. Otherwise, on iff `${CI_METRICS_DIR}/enabled` exists (written by the runner pre-job hook `job-started.sh`, which evaluates
+   the per-env / per-repo / per-workflow allow/deny lists). On runners without the hook the file is absent → metrics are off.
 
-The action also propagates the workflow `CI_METRICS_ENABLED` override to the same file (touch on `'true'`, remove on `'false'`)
-so the post-job `job-completed.sh` hook sees the same decision the cache action did. Workflows that don't use this action and
-still want to override can add the equivalent 4-line setup step (`case ... touch/rm $CI_METRICS_DIR/enabled`).
+When the gate resolves to "off", the cache flow runs exactly as before — no metrics steps, no JSON file, and `cache-size-bytes` is empty.
+The other outputs (`cache-hit`, `cache-matched-key`, `restore-key-hit`, `backend`) are unaffected.
 
 **Example — partial restore-key hit (primary missed, prefix-matched older entry restored, then re-saved under primary key):**
 

--- a/action.yml
+++ b/action.yml
@@ -244,11 +244,6 @@ runs:
         echo "cache-hit=${CACHE_HIT}" >> "$GITHUB_OUTPUT"
         echo "matched-key=${MATCHED_KEY}" >> "$GITHUB_OUTPUT"
 
-    # CI-metrics gating.
-    # On Linux: gate evaluates the presence-only file written by the runner pre-job hook (always runs).
-    # On non-Linux: gate only runs when CI_METRICS_ENABLED is explicitly set in the workflow env.
-    # Workflow-level `env: { CI_METRICS_ENABLED: 'true'|'false' }` always wins over the file.
-    # The step also mutates the file in the workflow-env override cases so the runner's post-job hook follows.
     - name: Resolve CI metrics gate
       id: ci-metrics-gate
       if: runner.os == 'Linux' || env.CI_METRICS_ENABLED == 'true'
@@ -270,11 +265,11 @@ runs:
             ;;
           *)
             if [[ -e "$CI_METRICS_DIR/enabled" ]]; then
-                decision=true
-                reason="Metrics enabled: runner-side decision file present at $CI_METRICS_DIR/enabled"
+              decision=true
+              reason="Metrics enabled: runner-side decision file present at $CI_METRICS_DIR/enabled"
             else
-                decision=false
-                reason="Metrics disabled: no signal (CI_METRICS_ENABLED unset and $CI_METRICS_DIR/enabled absent)"
+              decision=false
+              reason="Metrics disabled: no signal (CI_METRICS_ENABLED unset and $CI_METRICS_DIR/enabled absent)"
             fi
             ;;
         esac


### PR DESCRIPTION
## Summary

Reverts the BUILD-11444 change that replaced the decision-file gate with an `env.CI_METRICS_ENABLED` check in this action. Restores the previous correct design (BUILD-11295).

**Changes:**
- Restore the `Resolve CI metrics gate` bash step (evaluates `CI_METRICS_ENABLED` YAML env first, then falls back to file presence at `${CI_METRICS_DIR:-/tmp/ci-metrics}/enabled`)
- Change `cache-metrics-prep` `if:` back to `steps.ci-metrics-gate.outputs.decision == 'true'`
- Fix `test-cache-metrics-runner-hook`: replace "Verify runner hook wrote CI_METRICS_ENABLED to GITHUB_ENV" with an approach-agnostic check (file or env var)
- Fix `test-cache-metrics-workflow-false`: restore decision-file simulation step and file-removal verification

**Why the revert:** the `env.CI_METRICS_ENABLED` gate only works when the pre-job hook writes `CI_METRICS_ENABLED` to `$GITHUB_ENV`. But `$GITHUB_ENV` writes by the hook override job-level YAML `env:` blocks (GitHub Actions precedence: GITHUB_ENV > job/workflow `env:`), so a workflow setting `env: CI_METRICS_ENABLED: 'false'` to opt out was silently ignored — the hook's write always won. The BUILD-11295 decision-file design avoids this: the bash gate step reads `CI_METRICS_ENABLED` from YAML env only (no hook writes it anymore), then checks the file for the runner-side signal.

## Companion PRs (revert plan — merge order matters)

**This PR must merge first.** Merging github-runners-infra or ci-ami-images without this PR causes a metrics outage (hooks write the file; gate still checks `env.CI_METRICS_ENABLED == 'true'` → always false).

- **This PR** (PR A) ← merge first
- `github-runners-infra` — https://github.com/SonarSource/github-runners-infra/pull/421 (PR B) ← deploy to DEV first, merge with PR C
- `ci-ami-images` — https://github.com/SonarSource/ci-ami-images/pull/389 (PR C) ← build new AMI from branch, merge with PR B
- `ci-github-actions` — https://github.com/SonarSource/ci-github-actions/pull/295 (PR D) ← independent
- sonar-dummy e2e — https://github.com/SonarSource/sonar-dummy/pull/618 (DO NOT MERGE — remove after e2e passes)

See BUILD-11444 Jira comment 939306 for the full revert plan.

## Test plan

- [ ] `test-cache-metrics-workflow-false` CI job passes (simulated file + workflow opt-out)
- [ ] `test-cache-metrics-runner-hook` CI job passes on real `sonar-xs` runner (approach-agnostic check)
- [ ] E2E on sonar-dummy dev runner (K8s — PR B deployed to DEV): metrics ON without override, metrics OFF with `env: CI_METRICS_ENABLED: 'false'`
- [ ] E2E on sonar-dummy WarpBuild dev AMI (PR C AMI built): metrics ON, file-gate confirmed