### PR TITLE
BUILD-11470 Use snake_case keys in CacheMetricsRecord JSON output

### DIFF
--- a/__tests__/cache-metrics.test.ts
+++ b/__tests__/cache-metrics.test.ts
@@ -122,18 +122,18 @@ describe('metricsFilePath / read / write', () => {
     writeMetricsFile(target, {
       step: 'x',
       key: 'k',
-      'restore-key-hit': null,
+      restore_key_hit: null,
       backend: 'github',
-      'cache-hit': false,
-      'size-bytes-restored': 0,
-      'size-bytes-at-end': null,
+      cache_hit: false,
+      size_bytes_restored: 0,
+      size_bytes_at_end: null,
       saved: null,
-      'timestamp-restored': '2026-05-12T00:00:00Z',
-      'timestamp-at-end': null,
+      timestamp_restored: '2026-05-12T00:00:00Z',
+      timestamp_at_end: null,
     });
     const parsed = JSON.parse(fs.readFileSync(target, 'utf-8'));
     expect(parsed.step).toBe('x');
-    expect(parsed['size-bytes-at-end']).toBeNull();
+    expect(parsed.size_bytes_at_end).toBeNull();
   });
 
   it('readMetricsFile returns {} for missing or invalid files', () => {
@@ -217,13 +217,13 @@ describe('cache-metrics-main', () => {
     expect(record.step).toBe('cache-python');
     expect(record.key).toBe('python-Linux-abc');
     expect(record.backend).toBe('s3');
-    expect(record['cache-hit']).toBe(true);
+    expect(record.cache_hit).toBe(true);
     // Exact hit: matched-key == primary key → restore-key-hit must be null.
-    expect(record['restore-key-hit']).toBeNull();
-    expect(record['size-bytes-restored']).toBeGreaterThanOrEqual(4096);
-    expect(record['size-bytes-at-end']).toBeNull();
+    expect(record.restore_key_hit).toBeNull();
+    expect(record.size_bytes_restored).toBeGreaterThanOrEqual(4096);
+    expect(record.size_bytes_at_end).toBeNull();
     expect(record.saved).toBeNull();
-    expect(record['timestamp-restored']).toMatch(/Z$/);
+    expect(record.timestamp_restored).toMatch(/Z$/);
 
     expect(core.setOutput).toHaveBeenCalledWith(
       'cache-size-bytes',
@@ -255,7 +255,7 @@ describe('cache-metrics-main', () => {
     const record = JSON.parse(
       fs.readFileSync(path.join(tmp, 'cache-cache-python.json'), 'utf-8')
     );
-    expect(record['restore-key-hit']).toBe(expected);
+    expect(record.restore_key_hit).toBe(expected);
   });
 
   it('skips on non-linux platforms', async () => {
@@ -313,14 +313,14 @@ describe('cache-metrics-post', () => {
       writeMetricsFile(metricsFile, {
         step: 'cache-python',
         key: 'k',
-        'restore-key-hit': null,
+        restore_key_hit: null,
         backend: 's3',
-        'cache-hit': false,
-        'size-bytes-restored': 0,
-        'size-bytes-at-end': null,
+        cache_hit: false,
+        size_bytes_restored: 0,
+        size_bytes_at_end: null,
         saved: null,
-        'timestamp-restored': '2026-05-12T10:00:00Z',
-        'timestamp-at-end': null,
+        timestamp_restored: '2026-05-12T10:00:00Z',
+        timestamp_at_end: null,
       });
 
       const state: Record<string, string> = {
@@ -335,12 +335,12 @@ describe('cache-metrics-post', () => {
       await run();
 
       const updated = JSON.parse(fs.readFileSync(metricsFile, 'utf-8'));
-      expect(updated['size-bytes-at-end']).toBeGreaterThanOrEqual(8192);
+      expect(updated.size_bytes_at_end).toBeGreaterThanOrEqual(8192);
       expect(updated.saved).toBe(true);
-      expect(updated['timestamp-at-end']).toMatch(/Z$/);
+      expect(updated.timestamp_at_end).toMatch(/Z$/);
       // restore-time fields preserved
       expect(updated.step).toBe('cache-python');
-      expect(updated['timestamp-restored']).toBe('2026-05-12T10:00:00Z');
+      expect(updated.timestamp_restored).toBe('2026-05-12T10:00:00Z');
     }
   );
 
@@ -360,14 +360,14 @@ describe('cache-metrics-post', () => {
     writeMetricsFile(metricsFile, {
       step: stepName,
       key: 'k',
-      'restore-key-hit': null,
+      restore_key_hit: null,
       backend,
-      'cache-hit': cacheHit,
-      'size-bytes-restored': cacheHit ? 100 : 0,
-      'size-bytes-at-end': null,
+      cache_hit: cacheHit,
+      size_bytes_restored: cacheHit ? 100 : 0,
+      size_bytes_at_end: null,
       saved: null,
-      'timestamp-restored': '2026-05-12T00:00:00Z',
-      'timestamp-at-end': null,
+      timestamp_restored: '2026-05-12T00:00:00Z',
+      timestamp_at_end: null,
     });
 
     const state: Record<string, string> = {

--- a/src/cache-metrics-main.ts
+++ b/src/cache-metrics-main.ts
@@ -34,14 +34,14 @@ export async function run(): Promise<void> {
     const record: CacheMetricsRecord = {
       step: slug,
       key: inputs.key,
-      'restore-key-hit': restoreKeyHit,
+      restore_key_hit: restoreKeyHit,
       backend: inputs.backend,
-      'cache-hit': inputs.cacheHit,
-      'size-bytes-restored': sizeBytes,
-      'size-bytes-at-end': null,
+      cache_hit: inputs.cacheHit,
+      size_bytes_restored: sizeBytes,
+      size_bytes_at_end: null,
       saved: null,
-      'timestamp-restored': timestamp,
-      'timestamp-at-end': null,
+      timestamp_restored: timestamp,
+      timestamp_at_end: null,
     };
 
     writeMetricsFile(file, record);

--- a/src/cache-metrics-post.ts
+++ b/src/cache-metrics-post.ts
@@ -30,14 +30,14 @@ export async function run(): Promise<void> {
     const record: CacheMetricsRecord = {
       step: prior.step ?? 'cache',
       key: prior.key ?? '',
-      'restore-key-hit': prior['restore-key-hit'] ?? null,
+      restore_key_hit: prior.restore_key_hit ?? null,
       backend: prior.backend ?? 'unknown',
-      'cache-hit': prior['cache-hit'] ?? cacheHit,
-      'size-bytes-restored': prior['size-bytes-restored'] ?? null,
-      'size-bytes-at-end': sizeBytes,
+      cache_hit: prior.cache_hit ?? cacheHit,
+      size_bytes_restored: prior.size_bytes_restored ?? null,
+      size_bytes_at_end: sizeBytes,
       saved,
-      'timestamp-restored': prior['timestamp-restored'] ?? null,
-      'timestamp-at-end': new Date().toISOString(),
+      timestamp_restored: prior.timestamp_restored ?? null,
+      timestamp_at_end: new Date().toISOString(),
     };
 
     writeMetricsFile(metricsFile, record);

--- a/src/cache-metrics.ts
+++ b/src/cache-metrics.ts
@@ -18,27 +18,27 @@ export interface CacheMetricsRecord {
   step: string;
   key: string;
   /**
-   * The prefix-matched restore key. Populated only when `cache-hit` is false AND a restore key matched (partial hit); null on exact hits
+   * The prefix-matched restore key. Populated only when `cache_hit` is false AND a restore key matched (partial hit); null on exact hits
    * and on misses.
    */
-  'restore-key-hit': string | null;
+  restore_key_hit: string | null;
   backend: string;
-  'cache-hit': boolean;
+  cache_hit: boolean;
   /** Size of the cache content at restore-time (0 on a miss with no partial hit). */
-  'size-bytes-restored': number | null;
+  size_bytes_restored: number | null;
   /**
    * Size of the cache content at end of job, measured in the post step BEFORE the cache action's save runs. Reflects what would be saved
    * if `saved` is true, or simply the path size at job end if `saved` is false (e.g. exact hit, where the cache action skips save and user
    * modifications are not persisted).
    */
-  'size-bytes-at-end': number | null;
+  size_bytes_at_end: number | null;
   /**
-   * Whether the cache action actually persists the cache at job end. False when `cache-hit` was true (exact match: cache action skips save)
+   * Whether the cache action actually persists the cache at job end. False when `cache_hit` was true (exact match: cache action skips save)
    * or when lookup-only` was set.
    */
   saved: boolean | null;
-  'timestamp-restored': string | null;
-  'timestamp-at-end': string | null;
+  timestamp_restored: string | null;
+  timestamp_at_end: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Renames all kebab-case fields in `CacheMetricsRecord` to snake_case ([BUILD-11470](https://sonarsource.atlassian.net/browse/BUILD-11470)):

| Old | New |
|---|---|
| `cache-hit` | `cache_hit` |
| `restore-key-hit` | `restore_key_hit` |
| `size-bytes-restored` | `size_bytes_restored` |
| `size-bytes-at-end` | `size_bytes_at_end` |
| `timestamp-restored` | `timestamp_restored` |
| `timestamp-at-end` | `timestamp_at_end` |

Action input names (`cache-hit`, `lookup-only`, etc. in `action.yml`) are unchanged — only the JSON output fields are renamed.

## Related PRs

Part of BUILD-11470 — three-repo change:
- This PR — interface + source + tests
- `github-runners-infra` — hook + fixtures: https://github.com/SonarSource/github-runners-infra/pull/417
- `ci-github-actions` — copy of the hook: https://github.com/SonarSource/ci-github-actions/pull/289

## Test plan

- [ ] All 54 unit tests pass (`npm test`)
- [ ] Pre-commit hooks pass

[BUILD-11470]: https://sonarsource.atlassian.net/browse/BUILD-11470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ