### PR TITLE
BUILD-11555 Emit cache metrics JSON on all platforms; restrict size measurement to Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,15 +150,17 @@ gh variable set CACHE_IMPORT_GITHUB --body "true"
 | `cache-matched-key` | The cache key for which a match was found — primary key on an exact hit, restore key on a partial hit, empty on a miss.                       |
 | `restore-key-hit`   | The restore key that was prefix-matched. Populated only when `cache-hit` is `false` AND a restore key matched (partial hit). Empty otherwise. |
 | `backend`           | The cache backend that was actually used (`github` or `s3`).                                                                                  |
-| `cache-size-bytes`  | Total size in bytes of the cached path(s) at restore-time (Linux only; empty on other platforms).                                             |
+| `cache-size-bytes`  | Total size in bytes of the cached path(s) at restore-time. Requires GNU `du` (Linux); empty on other platforms.                               |
 
 ### Pipeline runtime metrics
 
-On Linux runners — and only when the layered gate below resolves to "on" — the action writes a per-invocation JSON record to
+When the gate resolves to "on", the action writes a per-invocation JSON record to
 `${CI_METRICS_DIR}/cache-${step}.json` for the [pipeline runtime metrics](https://sonarsource.atlassian.net/browse/BUILD-11068)
 `job-completed.sh` hook to ingest. The output directory is taken from the `CI_METRICS_DIR` environment variable (provided by the
 ARC pod template / WarpBuild AMI); it falls back to `/tmp/ci-metrics` when the variable is unset or empty.
-The record captures both the restore-time size and the pre-save size, plus whether the cache was actually saved.
+The record is written on all platforms once the gate resolves to "on" (see Gate resolution below).
+Size fields (`size_bytes_restored`, `size_bytes_at_end`) are `null` on non-Linux (no GNU `du`);
+all other fields (`cache_hit`, `restore_key_hit`, `backend`, `saved`, timestamps, `key`) are populated on every platform.
 
 **Gate resolution** ([BUILD-11295](https://sonarsource.atlassian.net/browse/BUILD-11295)):
 

--- a/__tests__/cache-metrics.test.ts
+++ b/__tests__/cache-metrics.test.ts
@@ -258,15 +258,35 @@ describe('cache-metrics-main', () => {
     expect(record.restore_key_hit).toBe(expected);
   });
 
-  it('skips on non-linux platforms', async () => {
+  it('writes JSON on non-Linux with null size fields; does not set cache-size-bytes output', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
     Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    const inputs: Record<string, string> = {
+      path: tmp,
+      key: 'python-Darwin-abc',
+      'cache-hit': 'false',
+      'matched-key': '',
+      backend: 's3',
+      'lookup-only': 'false',
+      'step-id': 'cache-python',
+    };
+    vi.mocked(core.getInput).mockImplementation((name) => inputs[name] ?? '');
 
     try {
       const { run } = await import('../src/cache-metrics-main');
       await run();
+
+      const written = path.join(tmp, 'cache-cache-python.json');
+      const record = JSON.parse(fs.readFileSync(written, 'utf-8'));
+      expect(record.key).toBe('python-Darwin-abc');
+      expect(record.size_bytes_restored).toBeNull();
+      expect(record.size_bytes_at_end).toBeNull();
+      expect(record.timestamp_restored).toMatch(/Z$/);
+      // cache-size-bytes must NOT be set on non-Linux
       expect(core.setOutput).not.toHaveBeenCalled();
-      expect(core.saveState).not.toHaveBeenCalled();
+      // state must still be saved so the post step can update the record
+      expect(core.saveState).toHaveBeenCalledWith('metricsFile', written);
     } finally {
       if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
     }
@@ -388,27 +408,47 @@ describe('cache-metrics-post', () => {
   it('skips when no state was saved (main step did not run)', async () => {
     vi.mocked(core.getState).mockReturnValue('');
 
-    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-    Object.defineProperty(process, 'platform', { value: 'linux' });
-    try {
-      const { run } = await import('../src/cache-metrics-post');
-      await run();
-      expect(core.info).toHaveBeenCalledWith(
-        expect.stringContaining('no state from main step')
-      );
-    } finally {
-      if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
-    }
+    const { run } = await import('../src/cache-metrics-post');
+    await run();
+    expect(core.info).toHaveBeenCalledWith(
+      expect.stringContaining('no state from main step')
+    );
   });
 
-  it('skips on non-linux platforms', async () => {
+  it('writes JSON on non-Linux with null size_bytes_at_end', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
     Object.defineProperty(process, 'platform', { value: 'darwin' });
 
+    const metricsFile = path.join(tmp, 'cache-x.json');
+    writeMetricsFile(metricsFile, {
+      step: 'x',
+      key: 'k',
+      restore_key_hit: null,
+      backend: 's3',
+      cache_hit: false,
+      size_bytes_restored: null,
+      size_bytes_at_end: null,
+      saved: null,
+      timestamp_restored: '2026-05-12T00:00:00Z',
+      timestamp_at_end: null,
+    });
+
+    const state: Record<string, string> = {
+      metricsFile,
+      path: tmp,
+      cacheHit: 'false',
+      lookupOnly: 'false',
+    };
+    vi.mocked(core.getState).mockImplementation((name) => state[name] ?? '');
+
     try {
       const { run } = await import('../src/cache-metrics-post');
       await run();
-      expect(core.getState).not.toHaveBeenCalled();
+
+      const updated = JSON.parse(fs.readFileSync(metricsFile, 'utf-8'));
+      expect(updated.size_bytes_at_end).toBeNull();
+      expect(updated.saved).toBe(true);
+      expect(updated.timestamp_at_end).toMatch(/Z$/);
     } finally {
       if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
     }

--- a/action.yml
+++ b/action.yml
@@ -64,9 +64,9 @@ outputs:
     value: ${{ steps.cache-backend.outputs.cache-backend }}
   cache-size-bytes:
     description: >
-      Total size in bytes of the cached path(s) at restore-time (Linux only; empty on other platforms).
+      Total size in bytes of the cached path(s) at restore-time. Requires GNU du (Linux); empty on other platforms.
       The action also writes a per-invocation JSON record to /tmp/ci-metrics/cache-${step}.json for the pipeline-runtime-metrics
-      job-completed hook to ingest.
+      job-completed hook to ingest. The JSON record is written on all platforms; only the size fields are null on non-Linux.
     value: ${{ steps.cache-metrics.outputs.cache-size-bytes }}
 
 runs:
@@ -245,12 +245,13 @@ runs:
         echo "matched-key=${MATCHED_KEY}" >> "$GITHUB_OUTPUT"
 
     # CI-metrics gating.
-    # The single source of truth is the presence-only file ${CI_METRICS_DIR}/enabled written by the runner's pre-job hook.
-    # Workflow-level `env: { CI_METRICS_ENABLED: 'true'|'false' }` always wins.
+    # On Linux: gate evaluates the presence-only file written by the runner pre-job hook (always runs).
+    # On non-Linux: gate only runs when CI_METRICS_ENABLED is explicitly set in the workflow env.
+    # Workflow-level `env: { CI_METRICS_ENABLED: 'true'|'false' }` always wins over the file.
     # The step also mutates the file in the workflow-env override cases so the runner's post-job hook follows.
     - name: Resolve CI metrics gate
       id: ci-metrics-gate
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' || env.CI_METRICS_ENABLED == 'true'
       shell: bash
       run: |
         echo "::group::CI metrics gate"

--- a/src/cache-metrics-main.ts
+++ b/src/cache-metrics-main.ts
@@ -10,16 +10,12 @@ import {
 
 export async function run(): Promise<void> {
   try {
-    if (process.platform !== 'linux') {
-      core.info(`cache-metrics: skipping on platform ${process.platform} (Linux-only)`);
-      return;
-    }
-
     const inputs = readInputs();
     const slug = slugifyStepId(inputs.stepId);
     const file = metricsFilePath(inputs.metricsDir, slug);
 
-    const sizeBytes = measureCacheBytes(inputs.path);
+    // Size measurement requires GNU `du -sb` (Linux only); null on other platforms.
+    const sizeBytes = process.platform === 'linux' ? measureCacheBytes(inputs.path) : null;
     const timestamp = new Date().toISOString();
 
     // `matchedKey` is the underlying cache action's `cache-matched-key` output:
@@ -45,7 +41,9 @@ export async function run(): Promise<void> {
     };
 
     writeMetricsFile(file, record);
-    core.setOutput('cache-size-bytes', sizeBytes);
+    if (sizeBytes !== null) {
+      core.setOutput('cache-size-bytes', sizeBytes);
+    }
 
     // Stash inputs for the post step (it does not receive `with:` again).
     core.saveState('metricsFile', file);
@@ -53,9 +51,8 @@ export async function run(): Promise<void> {
     core.saveState('cacheHit', inputs.cacheHit ? 'true' : 'false');
     core.saveState('lookupOnly', inputs.lookupOnly ? 'true' : 'false');
 
-    core.info(
-      `cache-metrics: restored size = ${sizeBytes} B, metrics written to ${file}`
-    );
+    const sizeMsg = sizeBytes === null ? 'n/a (non-Linux)' : `${sizeBytes} B`;
+    core.info(`cache-metrics: restored size = ${sizeMsg}, metrics written to ${file}`);
   } catch (error) {
     // Fail-open: metrics issues must never break the cache flow.
     core.warning(

--- a/src/cache-metrics-post.ts
+++ b/src/cache-metrics-post.ts
@@ -8,10 +8,6 @@ import {
 
 export async function run(): Promise<void> {
   try {
-    if (process.platform !== 'linux') {
-      return;
-    }
-
     const metricsFile = core.getState('metricsFile');
     if (!metricsFile) {
       core.info('cache-metrics: no state from main step — skipping post-measurement');
@@ -22,7 +18,8 @@ export async function run(): Promise<void> {
     const cacheHit = core.getState('cacheHit') === 'true';
     const lookupOnly = core.getState('lookupOnly') === 'true';
 
-    const sizeBytes = measureCacheBytes(pathInput);
+    // Size measurement requires GNU `du -sb` (Linux only); null on other platforms.
+    const sizeBytes = process.platform === 'linux' ? measureCacheBytes(pathInput) : null;
     // The cache action skips save when it found an exact-match hit, or when in lookup-only mode.
     const saved = !lookupOnly && !cacheHit;
 
@@ -41,9 +38,8 @@ export async function run(): Promise<void> {
     };
 
     writeMetricsFile(metricsFile, record);
-    core.info(
-      `cache-metrics: saved size = ${sizeBytes} B, saved=${saved}, updated ${metricsFile}`
-    );
+    const sizeMsg = sizeBytes === null ? 'n/a (non-Linux)' : `${sizeBytes} B`;
+    core.info(`cache-metrics: saved size = ${sizeMsg}, saved=${saved}, updated ${metricsFile}`);
   } catch (error) {
     // Fail-open: metrics issues must never break the cache flow.
     core.warning(


### PR DESCRIPTION
## Summary

The `process.platform !== 'linux'` guards in `cache-metrics-main` and `cache-metrics-post` were blocking **all** metrics functionality on macOS and Windows — including the entirely cross-platform JSON writing. Only `measureCacheBytes()` genuinely requires Linux (GNU `du -sb`).

**What changes:**
- JSON records (`cache_hit`, `key`, `backend`, `restore_key_hit`, `saved`, timestamps) are now written on all platforms
- Size fields (`size_bytes_restored`, `size_bytes_at_end`) remain `null` on non-Linux
- `cache-size-bytes` output is only set on Linux (unchanged from today)
- State (`metricsFile`, `path`, `cacheHit`, `lookupOnly`) is now saved on all platforms so the post step can update the record

**What does NOT change:**
- The gate mechanism (`CI_METRICS_ENABLED`) — the runner pre-job hook only runs on Linux today, so macOS/Windows users would need `env: CI_METRICS_ENABLED: 'true'` to opt in explicitly
- `github-runners-infra`, `ci-ami-images`, `ci-github-actions` — no changes

## Test plan

- [x] All 54 unit tests pass
- [x] Pre-commit passes
- [ ] `test-s3-cache-windows` CI job implicitly verifies JSON is written without crashing on Windows