### PR TITLE
BUILD-11686 Rebuild cache-metrics dist to emit snake_case JSON keys

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -417,7 +417,7 @@ jobs:
           for f in "${files[@]}"; do
             echo "--- $f ---"
             cat "$f"
-            jq -e '.step, .key, .backend, ."cache-hit", ."size-bytes-restored", ."timestamp-restored"' "$f" >/dev/null
+            jq -e '.step, .key, .backend, .cache_hit, .size_bytes_restored, .timestamp_restored' "$f" >/dev/null
           done
 
       - name: Populate cache path so the post-step measures a saved size

--- a/cache-metrics/dist/main/index.js
+++ b/cache-metrics/dist/main/index.js
@@ -31069,14 +31069,11 @@ const core = __importStar(__nccwpck_require__(7484));
 const cache_metrics_1 = __nccwpck_require__(5945);
 async function run() {
     try {
-        if (process.platform !== 'linux') {
-            core.info(`cache-metrics: skipping on platform ${process.platform} (Linux-only)`);
-            return;
-        }
         const inputs = (0, cache_metrics_1.readInputs)();
         const slug = (0, cache_metrics_1.slugifyStepId)(inputs.stepId);
         const file = (0, cache_metrics_1.metricsFilePath)(inputs.metricsDir, slug);
-        const sizeBytes = (0, cache_metrics_1.measureCacheBytes)(inputs.path);
+        // Size measurement requires GNU `du -sb` (Linux only); null on other platforms.
+        const sizeBytes = process.platform === 'linux' ? (0, cache_metrics_1.measureCacheBytes)(inputs.path) : null;
         const timestamp = new Date().toISOString();
         // `matchedKey` is the underlying cache action's `cache-matched-key` output:
         //   - exact hit  → equal to `inputs.key` (the primary key); `cacheHit` is true.
@@ -31089,23 +31086,26 @@ async function run() {
         const record = {
             step: slug,
             key: inputs.key,
-            'restore-key-hit': restoreKeyHit,
+            restore_key_hit: restoreKeyHit,
             backend: inputs.backend,
-            'cache-hit': inputs.cacheHit,
-            'size-bytes-restored': sizeBytes,
-            'size-bytes-at-end': null,
+            cache_hit: inputs.cacheHit,
+            size_bytes_restored: sizeBytes,
+            size_bytes_at_end: null,
             saved: null,
-            'timestamp-restored': timestamp,
-            'timestamp-at-end': null,
+            timestamp_restored: timestamp,
+            timestamp_at_end: null,
         };
         (0, cache_metrics_1.writeMetricsFile)(file, record);
-        core.setOutput('cache-size-bytes', sizeBytes);
+        if (sizeBytes !== null) {
+            core.setOutput('cache-size-bytes', sizeBytes);
+        }
         // Stash inputs for the post step (it does not receive `with:` again).
         core.saveState('metricsFile', file);
         core.saveState('path', inputs.path);
         core.saveState('cacheHit', inputs.cacheHit ? 'true' : 'false');
         core.saveState('lookupOnly', inputs.lookupOnly ? 'true' : 'false');
-        core.info(`cache-metrics: restored size = ${sizeBytes} B, metrics written to ${file}`);
+        const sizeMsg = sizeBytes === null ? 'n/a (non-Linux)' : `${sizeBytes} B`;
+        core.info(`cache-metrics: restored size = ${sizeMsg}, metrics written to ${file}`);
     }
     catch (error) {
         // Fail-open: metrics issues must never break the cache flow.

--- a/cache-metrics/dist/post/index.js
+++ b/cache-metrics/dist/post/index.js
@@ -31069,9 +31069,6 @@ const core = __importStar(__nccwpck_require__(7484));
 const cache_metrics_1 = __nccwpck_require__(5945);
 async function run() {
     try {
-        if (process.platform !== 'linux') {
-            return;
-        }
         const metricsFile = core.getState('metricsFile');
         if (!metricsFile) {
             core.info('cache-metrics: no state from main step — skipping post-measurement');
@@ -31080,24 +31077,26 @@ async function run() {
         const pathInput = core.getState('path');
         const cacheHit = core.getState('cacheHit') === 'true';
         const lookupOnly = core.getState('lookupOnly') === 'true';
-        const sizeBytes = (0, cache_metrics_1.measureCacheBytes)(pathInput);
+        // Size measurement requires GNU `du -sb` (Linux only); null on other platforms.
+        const sizeBytes = process.platform === 'linux' ? (0, cache_metrics_1.measureCacheBytes)(pathInput) : null;
         // The cache action skips save when it found an exact-match hit, or when in lookup-only mode.
         const saved = !lookupOnly && !cacheHit;
         const prior = (0, cache_metrics_1.readMetricsFile)(metricsFile);
         const record = {
             step: prior.step ?? 'cache',
             key: prior.key ?? '',
-            'restore-key-hit': prior['restore-key-hit'] ?? null,
+            restore_key_hit: prior.restore_key_hit ?? null,
             backend: prior.backend ?? 'unknown',
-            'cache-hit': prior['cache-hit'] ?? cacheHit,
-            'size-bytes-restored': prior['size-bytes-restored'] ?? null,
-            'size-bytes-at-end': sizeBytes,
+            cache_hit: prior.cache_hit ?? cacheHit,
+            size_bytes_restored: prior.size_bytes_restored ?? null,
+            size_bytes_at_end: sizeBytes,
             saved,
-            'timestamp-restored': prior['timestamp-restored'] ?? null,
-            'timestamp-at-end': new Date().toISOString(),
+            timestamp_restored: prior.timestamp_restored ?? null,
+            timestamp_at_end: new Date().toISOString(),
         };
         (0, cache_metrics_1.writeMetricsFile)(metricsFile, record);
-        core.info(`cache-metrics: saved size = ${sizeBytes} B, saved=${saved}, updated ${metricsFile}`);
+        const sizeMsg = sizeBytes === null ? 'n/a (non-Linux)' : `${sizeBytes} B`;
+        core.info(`cache-metrics: saved size = ${sizeMsg}, saved=${saved}, updated ${metricsFile}`);
     }
     catch (error) {
         // Fail-open: metrics issues must never break the cache flow.


### PR DESCRIPTION
## What

Rebuild the committed `cache-metrics` bundles (`cache-metrics/dist/{main,post}/index.js`) so the deployed action emits **snake_case** JSON keys, matching the TypeScript source and the `report-ci-metrics` consumer.

## Why

The committed dist predated [BUILD-11470](https://sonarsource.atlassian.net/browse/BUILD-11470) (commit `8088385`), which renamed the `CacheMetricsRecord` JSON keys to snake_case in `src/cache-metrics.ts`, but `dist/` was never rebuilt (last touched by `a9ef067`, 2026-05-21). The stale bundle still emitted hyphenated keys:

| Stale dist | Source / consumer |
|---|---|
| `cache-hit` | `cache_hit` |
| `restore-key-hit` | `restore_key_hit` |
| `size-bytes-restored` | `size_bytes_restored` |
| `size-bytes-at-end` | `size_bytes_at_end` |

As a result every cache field read as `null` in the CI Metrics report (e.g. sonar-dummy PR #624: `Build` restored 154 MB yet the report showed `Hit: no` / `Size Restored: n/a`).

## How

```
npm run build:metrics-main
npm run build:metrics-post
```

Only the two `index.js` bundles changed.

## Verification

- Both bundles now emit `cache_hit`, `restore_key_hit`, `size_bytes_restored`, `size_bytes_at_end`.
- The single remaining `'cache-hit'` literal in each bundle is the GitHub Action **input** name (`core.getInput('cache-hit')`) — correct and unrelated.
- `npm test` — 43 passed, 11 skipped, 0 failed.

## Follow-up (not in this PR)

Per the ticket, consider a CI check that fails when `dist/` is out of sync with `src/` (rebuild + `git diff --exit-code`) to prevent recurrence.

Closes BUILD-11686

[BUILD-11470]: https://sonarsource.atlassian.net/browse/BUILD-11470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **Logic adjustments:**
  - Modified cache measurement to gracefully return `null` on non-Linux platforms instead of exiting the process.
  - Updated `core.setOutput` logic to ensure `cache-size-bytes` is only set when valid data exists.
- **Improved logging:**
  - Updated information messages to explicitly report `n/a (non-Linux)` when cache size measurement is skipped.
- **Test automation:**
  - Updated `.github/workflows/test-action.yml` to assert on `snake_case` JSON keys in CI metrics output.

<sub>This will update automatically on new commits.</sub>