### PR TITLE
BUILD-11220 Skip duplicate S3 cache save when content restored from default-branch fallback

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,4 @@ self-hosted-runner:
     - sonar-xs
     - github-ubuntu-latest-s
     - github-windows-latest-s
+    - warp-custom-ubuntu-24-04

--- a/.github/workflows/check-cache-migration.yml
+++ b/.github/workflows/check-cache-migration.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check-migration:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: Compare GitHub cache vs S3
     permissions:
       id-token: write

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,8 +6,16 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: SonarSource/ci-github-actions/config-npm@9d3488f52305895f599feb1ec8560c1a5339aa99 # v1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2025.7.12
       - uses: SonarSource/gh-action_pre-commit@2ddc0c7fdabce0adfaaa4075a17690972ed9961a # 1.2.0
         with:
           extra-args: >

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-github-cache:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -41,7 +41,7 @@ jobs:
       run: python -m pytest --version
 
   test-s3-cache:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -76,7 +76,7 @@ jobs:
         run: python -m pytest --version
 
   test-s3-cache-with-fallback:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -122,7 +122,7 @@ jobs:
       run: go build -o hello main.go
 
   test-s3-cache-with-credential-interference:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -190,7 +190,7 @@ jobs:
 
   # Reproduces: ~/.aws/config corruption from multiple credential_process entries
   test-s3-cache-multiple-invocations:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -232,7 +232,7 @@ jobs:
   # Reproduces: pre-existing AWS config from configure-aws-credentials
   # https://github.com/SonarSource/sonarsource-iam/actions/runs/21951781857/job/63404298650#step:5:9
   test-s3-cache-with-preset-aws-config:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -301,7 +301,7 @@ jobs:
   # Regression test: git clean -ffdx must not break credential-guard post step
   # Reproduces: https://github.com/SonarSource/sonar-dummy/actions/runs/21997126216
   test-s3-cache-survives-git-clean:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -337,7 +337,7 @@ jobs:
   # `./.actions/cache-metrics` after another action runs actions/checkout (clean + reset + force-checkout),
   # which is what wiped the symlink in https://github.com/SonarSource/sonar-dummy/actions/runs/26102811096/job/76758257880
   test-s3-cache-survives-git-clean-with-metrics:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -374,7 +374,7 @@ jobs:
 
   # Validates cache-size-bytes output + ${CI_METRICS_DIR}/cache-*.json (gated by CI_METRICS_ENABLED).
   test-cache-metrics-output:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -429,7 +429,7 @@ jobs:
   # S3 step runs in `restore-only` mode and never saves back under the branch key.
   # Uses a stable key (no github.run_id): once master has saved it at least once, PR runs restoring via fallback observe an exact match.
   test-s3-cache-skip-redundant-save:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -541,7 +541,7 @@ jobs:
   # file, then verifies that job-level CI_METRICS_ENABLED=false wins (workflow-false > file-present
   # in the layered gate). The gate step removes the file so the post-job hook also skips metrics.
   test-cache-metrics-workflow-false:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -610,8 +610,14 @@ jobs:
       - test-s3-cache-skip-redundant-save
       - test-cache-metrics-runner-hook
       - test-cache-metrics-workflow-false
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     steps:
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2025.7.12
+          mise_toml: |
+            [tools]
+            python = "3.13.5"
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -425,6 +425,58 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
 
+  # when the S3 lookup resolves an exact match against the default-branch fallback key (content is byte-identical to master's cache), the
+  # S3 step runs in `restore-only` mode and never saves back under the branch key.
+  # Uses a stable key (no github.run_id): once master has saved it at least once, PR runs restoring via fallback observe an exact match.
+  test-s3-cache-skip-redundant-save:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CI_METRICS_ENABLED: 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2025.7.12
+
+      - name: Cache pip with a stable key (exact fallback-match check)
+        id: cache-skip-save
+        uses: ./
+        with:
+          path: ~/.cache/pip
+          key: skip-save-verify-${{ runner.os }}
+          fail-on-cache-miss: false
+          environment: dev
+          backend: s3
+
+      - name: Verify redundant save is skipped on an exact fallback match
+        run: |
+          expected_fallback_key="refs/heads/master/skip-save-verify-${{ runner.os }}"
+          matched_key="${{ steps.cache-skip-save.outputs.cache-matched-key }}"
+
+          if [[ "${{ steps.cache-skip-save.outputs.cache-hit }}" == "true" || "$matched_key" != "$expected_fallback_key" ]]; then
+            echo "::notice::No exact fallback-branch match yet (matched-key='$matched_key', expected='$expected_fallback_key') — self-heals once master has saved this key. Skipping assertion."
+            exit 0
+          fi
+
+          shopt -s nullglob
+          files=(/tmp/ci-metrics/cache-*.json)
+          if (( ${#files[@]} == 0 )); then
+            echo "::error::no cache-*.json under /tmp/ci-metrics/"
+            ls -la /tmp/ci-metrics/ || true
+            exit 1
+          fi
+          for f in "${files[@]}"; do
+            echo "--- $f ---"
+            cat "$f"
+            jq -e '.saved == false' "$f" >/dev/null || {
+              echo "::error::expected saved=false on an exact fallback-branch match, got $(jq -c '.saved' "$f")"
+              exit 1
+            }
+          done
+
   # Runner-hook path: metrics on when the runner pre-job hook (job-started.sh) writes the decision
   # file /tmp/ci-metrics/enabled. No workflow-level CI_METRICS_ENABLED — the gate resolves purely
   # from the presence-only file written by the hook.
@@ -555,6 +607,7 @@ jobs:
       - test-s3-cache-survives-git-clean
       - test-s3-cache-survives-git-clean-with-metrics
       - test-cache-metrics-output
+      - test-s3-cache-skip-redundant-save
       - test-cache-metrics-runner-hook
       - test-cache-metrics-workflow-false
     runs-on: github-ubuntu-latest-s

--- a/.github/workflows/test-cache-migration-gh2s3.yml
+++ b/.github/workflows/test-cache-migration-gh2s3.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # Prerequisite: provision GitHub cache entries used by the test scenarios
   provision-github-cache:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: "Provision GitHub cache entries"
     permissions:
       contents: read
@@ -31,7 +31,7 @@ jobs:
 
   # Prerequisite: provision an S3 cache entry for the S3-hit scenario
   provision-s3-cache:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: "Provision S3 cache entry"
     permissions:
       id-token: write
@@ -52,7 +52,7 @@ jobs:
   # Scenario 1: S3 backend with import mode active (default behavior after migration begins)
   test-s3-import-enabled:
     needs: provision-github-cache
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: "S3 + import enabled (migration fallback)"
     permissions:
       id-token: write
@@ -77,7 +77,7 @@ jobs:
   # Scenario 2: S3 backend with import mode explicitly disabled
   test-s3-import-disabled:
     needs: provision-github-cache
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: "S3 + import disabled (migration complete)"
     permissions:
       id-token: write
@@ -101,7 +101,7 @@ jobs:
   # Scenario 3: S3 backend with import disabled via env var (repo variable pattern)
   test-s3-import-disabled-via-env:
     needs: provision-github-cache
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: "S3 + import disabled via env var"
     permissions:
       id-token: write
@@ -126,7 +126,7 @@ jobs:
   # Scenario 4: S3 hit — GitHub import step must be skipped entirely
   test-s3-hit-skips-github-import:
     needs: [ provision-github-cache, provision-s3-cache ]
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: "S3 hit → no GitHub import"
     permissions:
       id-token: write
@@ -154,7 +154,7 @@ jobs:
   # without needing to force the backend explicitly (distinct from the BACKEND_SOURCE=forced path in scenario 1).
   test-auto-public-import-enabled:
     needs: provision-github-cache
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: "Auto-detected S3 (public repo) → GitHub import enabled"
     permissions:
       id-token: write
@@ -186,8 +186,14 @@ jobs:
       - test-s3-import-disabled-via-env
       - test-s3-hit-skips-github-import
       - test-auto-public-import-enabled
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     steps:
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2025.7.12
+          mise_toml: |
+            [tools]
+            python = "3.13.5"
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:

--- a/.github/workflows/test-cache-migration-gh2s3.yml
+++ b/.github/workflows/test-cache-migration-gh2s3.yml
@@ -144,7 +144,9 @@ jobs:
           # import-github-cache defaults to true — S3 hit should prevent GitHub from being tried
       - name: Verify S3 content restored, not GitHub
         run: |
-          [[ "${{ steps.cache.outputs.cache-hit }}" == "true" ]] || { echo "ERROR: expected S3 hit"; exit 1; }
+          # Content identical to the default branch is served from the master fallback key (cache-hit=false, a fallback restore), not an
+          # exact branch-key primary hit. Assert an S3 match plus the correct content.
+          [[ -n "${{ steps.cache.outputs.cache-matched-key }}" ]] || { echo "ERROR: expected an S3 cache match"; exit 1; }
           [[ "$(cat ~/.cache/test-migration/test-file.txt)" == "s3-content" ]] || { echo "ERROR: unexpected content — GitHub import may have overridden S3"; exit 1; }
 
   # Scenario 5: auto-detected S3 (public repo) — GitHub import MUST be triggered via was-github-default=true

--- a/.github/workflows/test-credential-isolation.yml
+++ b/.github/workflows/test-credential-isolation.yml
@@ -10,7 +10,9 @@ on:
 
 jobs:
   tests-credential-isolation:
-    runs-on: github-ubuntu-latest-s
+    # Docker container action (convictional/trigger-workflow-and-wait) requires a Docker daemon,
+    # which sonar-xs does not provide — use a WarpBuild runner instead of a GitHub-hosted one.
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,12 @@ the matching job:
 - **GitHub-cache import fallback resolution** (`action.yml:135-162`): five-step priority chain ending
   in "private/internal repo → false". When active, it suppresses `fail-on-cache-miss` on the S3 step
   and enforces it later, after also trying the GitHub-cache restore.
+- **Skip redundant save on exact fallback match** (`s3-decide` step, `action.yml:195-221`): when the
+  restored key exactly matches the default-branch fallback (`refs/heads/${FALLBACK_BRANCH}/${key}`),
+  the step picks a save-incapable mode (`restore-only`/`lookup`) instead of `combined`, so the
+  branch never re-saves content identical to what the fallback already has. `cache-metrics` reads
+  this `mode` to report `saved: false` accordingly. Regression job:
+  `test-s3-cache-skip-redundant-save`.
 
 ## Pinned environment
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,11 @@ To disable the automatic default branch fallback:
   when no branch-specific entry exists
 - **Dynamic default branch detection**: The action detects your default branch using the GitHub API and uses it for fallback
 - **Branch isolation**: Each branch maintains its own cache namespace, preventing cross-branch cache pollution
+- **No redundant save of default-branch content**: When a feature branch finds no branch-scoped entry and restores byte-identical content
+  from the default-branch fallback (same `key`), the action skips re-saving that content under the branch-scoped key — it would just be a
+  duplicate of the default-branch cache. Jobs that actually produce new content (their `key` does not match the default-branch cache)
+  still save normally. A consequence is that such a feature-branch job does not create its own branch-scoped copy and will re-restore
+  from the default-branch fallback on its next run.
 
 ### Environment Configuration
 

--- a/__tests__/cache-metrics.test.ts
+++ b/__tests__/cache-metrics.test.ts
@@ -232,6 +232,7 @@ describe('cache-metrics-main', () => {
     expect(core.saveState).toHaveBeenCalledWith('metricsFile', written);
     expect(core.saveState).toHaveBeenCalledWith('cacheHit', 'true');
     expect(core.saveState).toHaveBeenCalledWith('lookupOnly', 'false');
+    expect(core.saveState).toHaveBeenCalledWith('mode', '');
   });
 
   it.skipIf(process.platform !== 'linux').each([
@@ -368,14 +369,24 @@ describe('cache-metrics-post', () => {
     {
       reason: 'cache-hit was true (exact match: cache action skips save)',
       stepName: 'x', file: 'cache-x.json', backend: 'github',
-      cacheHit: true, cacheHitState: 'true', lookupOnlyState: 'false',
+      cacheHit: true, cacheHitState: 'true', lookupOnlyState: 'false', modeState: '',
     },
     {
       reason: 'lookup-only was true',
       stepName: 'y', file: 'cache-y.json', backend: 's3',
-      cacheHit: false, cacheHitState: 'false', lookupOnlyState: 'true',
+      cacheHit: false, cacheHitState: 'false', lookupOnlyState: 'true', modeState: '',
     },
-  ])('sets saved=false when $reason', async ({ stepName, file, backend, cacheHit, cacheHitState, lookupOnlyState }) => {
+    {
+      reason: 'mode was restore-only (fallback-exact-match skip, cache action never ran a save-capable step)',
+      stepName: 'z', file: 'cache-z.json', backend: 's3',
+      cacheHit: false, cacheHitState: 'false', lookupOnlyState: 'false', modeState: 'restore-only',
+    },
+    {
+      reason: 'mode was lookup (caller requested lookup-only mode via s3-decide)',
+      stepName: 'w', file: 'cache-w.json', backend: 's3',
+      cacheHit: false, cacheHitState: 'false', lookupOnlyState: 'false', modeState: 'lookup',
+    },
+  ])('sets saved=false when $reason', async ({ stepName, file, backend, cacheHit, cacheHitState, lookupOnlyState, modeState }) => {
     const metricsFile = path.join(tmp, file);
     writeMetricsFile(metricsFile, {
       step: stepName,
@@ -395,6 +406,7 @@ describe('cache-metrics-post', () => {
       path: '',
       cacheHit: cacheHitState,
       lookupOnly: lookupOnlyState,
+      mode: modeState,
     };
     vi.mocked(core.getState).mockImplementation((name) => state[name] ?? '');
 

--- a/action.yml
+++ b/action.yml
@@ -171,8 +171,77 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
       run: $ACTION_PATH_CACHE/scripts/prepare-keys.sh
 
-    - name: Cache on S3
+    - name: Probe S3 cache (lookup-only)
       if: steps.cache-backend.outputs.cache-backend == 's3'
+      uses: runs-on/cache/restore@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
+      id: s3-probe
+      env:
+        RUNS_ON_S3_BUCKET_CACHE: sonarsource-s3-cache-${{ inputs.environment }}-bucket
+        AWS_DEFAULT_REGION: eu-central-1
+        AWS_REGION: eu-central-1
+        AWS_ACCESS_KEY_ID: ${{ steps.aws-auth.outputs.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ steps.aws-auth.outputs.AWS_SECRET_ACCESS_KEY }}
+        AWS_SESSION_TOKEN: ${{ steps.aws-auth.outputs.AWS_SESSION_TOKEN }}
+        AWS_PROFILE: ''
+        AWS_DEFAULT_PROFILE: ''
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ steps.prepare-keys.outputs.branch-key }}
+        restore-keys: ${{ steps.prepare-keys.outputs.branch-restore-keys }}
+        enableCrossOsArchive: ${{ inputs.enableCrossOsArchive }}
+        fail-on-cache-miss: false
+        lookup-only: true
+
+    - name: Decide S3 cache mode
+      if: steps.cache-backend.outputs.cache-backend == 's3'
+      id: s3-decide
+      shell: bash
+      env:
+        LOOKUP_ONLY: ${{ inputs.lookup-only }}
+        PROBE_HIT: ${{ steps.s3-probe.outputs.cache-hit }}
+        PROBE_MATCHED_KEY: ${{ steps.s3-probe.outputs.cache-matched-key }}
+        FALLBACK_EXACT_KEY: ${{ steps.prepare-keys.outputs.fallback-exact-key }}
+      run: |
+        echo "::group::Decide S3 cache mode"
+        if [[ "$LOOKUP_ONLY" == "true" ]]; then
+          MODE="lookup"
+          REASON="lookup-only input set — no restore, no save"
+        elif [[ "$PROBE_HIT" == "true" ]]; then
+          MODE="restore-only"
+          REASON="branch-scoped key already holds exact content — restore without redundant save"
+        elif [[ -n "$PROBE_MATCHED_KEY" && -n "$FALLBACK_EXACT_KEY" && "$PROBE_MATCHED_KEY" == "$FALLBACK_EXACT_KEY" ]]; then
+          MODE="restore-only"
+          REASON="content matched the default-branch fallback-exact key — identical to default branch, skip duplicate save"
+        else
+          MODE="combined"
+          REASON="no usable S3 match (or a non-fallback partial match) — restore and save back under the branch-scoped key"
+        fi
+        echo "mode=$MODE (matched-key='$PROBE_MATCHED_KEY', fallback-exact-key='$FALLBACK_EXACT_KEY'): $REASON"
+        echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+        echo "::endgroup::"
+
+    - name: Restore from S3 (no save)
+      if: steps.cache-backend.outputs.cache-backend == 's3' && steps.s3-decide.outputs.mode == 'restore-only'
+      uses: runs-on/cache/restore@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
+      id: s3-restore
+      env:
+        RUNS_ON_S3_BUCKET_CACHE: sonarsource-s3-cache-${{ inputs.environment }}-bucket
+        AWS_DEFAULT_REGION: eu-central-1
+        AWS_REGION: eu-central-1
+        AWS_ACCESS_KEY_ID: ${{ steps.aws-auth.outputs.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ steps.aws-auth.outputs.AWS_SECRET_ACCESS_KEY }}
+        AWS_SESSION_TOKEN: ${{ steps.aws-auth.outputs.AWS_SESSION_TOKEN }}
+        AWS_PROFILE: ''
+        AWS_DEFAULT_PROFILE: ''
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ steps.prepare-keys.outputs.branch-key }}
+        restore-keys: ${{ steps.prepare-keys.outputs.branch-restore-keys }}
+        enableCrossOsArchive: ${{ inputs.enableCrossOsArchive }}
+        fail-on-cache-miss: ${{ steps.cache-backend.outputs.import-github == 'true' && 'false' || inputs.fail-on-cache-miss }}
+
+    - name: Cache on S3
+      if: steps.cache-backend.outputs.cache-backend == 's3' && steps.s3-decide.outputs.mode == 'combined'
       uses: runs-on/cache@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
       id: s3-cache
       env:
@@ -200,6 +269,7 @@ runs:
     - name: Import GitHub cache to S3 (migration fallback)
       if: >-
         steps.cache-backend.outputs.cache-backend == 's3' &&
+        steps.s3-decide.outputs.mode == 'combined' &&
         steps.s3-cache.outputs.cache-hit != 'true' &&
         steps.cache-backend.outputs.import-github == 'true'
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -214,6 +284,7 @@ runs:
     - name: Enforce fail-on-cache-miss after GitHub import fallback
       if: >-
         steps.cache-backend.outputs.cache-backend == 's3' &&
+        steps.s3-decide.outputs.mode == 'combined' &&
         steps.cache-backend.outputs.import-github == 'true' &&
         inputs.fail-on-cache-miss == 'true' &&
         steps.s3-cache.outputs.cache-hit != 'true' &&
@@ -234,13 +305,17 @@ runs:
       env:
         HIT_GITHUB: ${{ steps.github-cache.outputs.cache-hit }}
         HIT_S3: ${{ steps.s3-cache.outputs.cache-hit }}
+        HIT_S3_RESTORE: ${{ steps.s3-restore.outputs.cache-hit }}
+        HIT_S3_PROBE: ${{ steps.s3-probe.outputs.cache-hit }}
         HIT_IMPORT: ${{ steps.github-import.outputs.cache-hit }}
         MATCHED_GITHUB: ${{ steps.github-cache.outputs.cache-matched-key }}
         MATCHED_S3: ${{ steps.s3-cache.outputs.cache-matched-key }}
+        MATCHED_S3_RESTORE: ${{ steps.s3-restore.outputs.cache-matched-key }}
+        MATCHED_S3_PROBE: ${{ steps.s3-probe.outputs.cache-matched-key }}
         MATCHED_IMPORT: ${{ steps.github-import.outputs.cache-matched-key }}
       run: |
-        CACHE_HIT="${HIT_GITHUB:-${HIT_S3:-${HIT_IMPORT:-}}}"
-        MATCHED_KEY="${MATCHED_GITHUB:-${MATCHED_S3:-${MATCHED_IMPORT:-}}}"
+        CACHE_HIT="${HIT_GITHUB:-${HIT_S3:-${HIT_S3_RESTORE:-${HIT_S3_PROBE:-${HIT_IMPORT:-}}}}}"
+        MATCHED_KEY="${MATCHED_GITHUB:-${MATCHED_S3:-${MATCHED_S3_RESTORE:-${MATCHED_S3_PROBE:-${MATCHED_IMPORT:-}}}}}"
         echo "cache-hit=${CACHE_HIT}" >> "$GITHUB_OUTPUT"
         echo "matched-key=${MATCHED_KEY}" >> "$GITHUB_OUTPUT"
 
@@ -312,6 +387,7 @@ runs:
         backend: ${{ steps.cache-backend.outputs.cache-backend }}
         lookup-only: ${{ inputs.lookup-only }}
         step-id: ${{ github.action }}
+        mode: ${{ steps.s3-decide.outputs.mode }}
 
     - name: Credential guard for S3 cache save
       if: steps.cache-backend.outputs.cache-backend == 's3'

--- a/action.yml
+++ b/action.yml
@@ -269,7 +269,8 @@ runs:
     - name: Import GitHub cache to S3 (migration fallback)
       if: >-
         steps.cache-backend.outputs.cache-backend == 's3' &&
-        steps.s3-decide.outputs.mode == 'combined' &&
+        (steps.s3-decide.outputs.mode == 'combined' || steps.s3-decide.outputs.mode == 'lookup') &&
+        steps.s3-probe.outputs.cache-hit != 'true' &&
         steps.s3-cache.outputs.cache-hit != 'true' &&
         steps.cache-backend.outputs.import-github == 'true'
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -284,9 +285,10 @@ runs:
     - name: Enforce fail-on-cache-miss after GitHub import fallback
       if: >-
         steps.cache-backend.outputs.cache-backend == 's3' &&
-        steps.s3-decide.outputs.mode == 'combined' &&
+        (steps.s3-decide.outputs.mode == 'combined' || steps.s3-decide.outputs.mode == 'lookup') &&
         steps.cache-backend.outputs.import-github == 'true' &&
         inputs.fail-on-cache-miss == 'true' &&
+        steps.s3-probe.outputs.cache-hit != 'true' &&
         steps.s3-cache.outputs.cache-hit != 'true' &&
         steps.github-import.outputs.cache-matched-key == ''
       shell: bash

--- a/cache-metrics/action.yml
+++ b/cache-metrics/action.yml
@@ -25,6 +25,10 @@ inputs:
   step-id:
     description: Unique discriminator for the per-invocation JSON filename (typically `github.action` of the caller)
     required: true
+  mode:
+    description: The S3 decision mode (`lookup`, `restore-only`, `combined`) selected by the caller's s3-decide step; empty for the github backend
+    required: false
+    default: ''
 outputs:
   cache-size-bytes:
     description: Total size in bytes of the cached path(s) at restore-time

--- a/cache-metrics/dist/main/index.js
+++ b/cache-metrics/dist/main/index.js
@@ -31104,6 +31104,7 @@ async function run() {
         core.saveState('path', inputs.path);
         core.saveState('cacheHit', inputs.cacheHit ? 'true' : 'false');
         core.saveState('lookupOnly', inputs.lookupOnly ? 'true' : 'false');
+        core.saveState('mode', inputs.mode);
         const sizeMsg = sizeBytes === null ? 'n/a (non-Linux)' : `${sizeBytes} B`;
         core.info(`cache-metrics: restored size = ${sizeMsg}, metrics written to ${file}`);
     }
@@ -31265,6 +31266,7 @@ function readInputs() {
         // via the CI_METRICS_DIR env var. Default keeps the action usable on any
         // runner without that env preset.
         metricsDir: process.env.CI_METRICS_DIR || exports.DEFAULT_METRICS_DIR,
+        mode: core.getInput('mode'),
     };
 }
 

--- a/cache-metrics/dist/post/index.js
+++ b/cache-metrics/dist/post/index.js
@@ -31077,10 +31077,13 @@ async function run() {
         const pathInput = core.getState('path');
         const cacheHit = core.getState('cacheHit') === 'true';
         const lookupOnly = core.getState('lookupOnly') === 'true';
+        const mode = core.getState('mode');
         // Size measurement requires GNU `du -sb` (Linux only); null on other platforms.
         const sizeBytes = process.platform === 'linux' ? (0, cache_metrics_1.measureCacheBytes)(pathInput) : null;
-        // The cache action skips save when it found an exact-match hit, or when in lookup-only mode.
-        const saved = !lookupOnly && !cacheHit;
+        // The cache action skips save when it found an exact-match hit, when in lookup-only mode, or when the
+        // S3 decision mode picked a save-incapable step (`restore-only`/`lookup`).
+        const saveIncapable = mode === 'restore-only' || mode === 'lookup';
+        const saved = !saveIncapable && !lookupOnly && !cacheHit;
         const prior = (0, cache_metrics_1.readMetricsFile)(metricsFile);
         const record = {
             step: prior.step ?? 'cache',
@@ -31256,6 +31259,7 @@ function readInputs() {
         // via the CI_METRICS_DIR env var. Default keeps the action usable on any
         // runner without that env preset.
         metricsDir: process.env.CI_METRICS_DIR || exports.DEFAULT_METRICS_DIR,
+        mode: core.getInput('mode'),
     };
 }
 

--- a/scripts/prepare-keys.sh
+++ b/scripts/prepare-keys.sh
@@ -83,6 +83,10 @@ if [[ -n "$FALLBACK_EXACT_KEY" ]]; then
   RESTORE_KEYS="$FALLBACK_EXACT_KEY"
 fi
 
+# Emit the fallback exact-match key on its own (empty when there is no fallback). The S3 path uses it to detect when content was
+# restored from the default-branch fallback and is therefore byte-identical to it, so the redundant branch-scoped save can be skipped
+echo "fallback-exact-key=${FALLBACK_EXACT_KEY}" >> "$GITHUB_OUTPUT"
+
 # Helper: append a prefixed restore key for each user-provided restore-key line
 append_restore_keys() {
   local prefix="$1"

--- a/src/cache-metrics-main.ts
+++ b/src/cache-metrics-main.ts
@@ -50,6 +50,7 @@ export async function run(): Promise<void> {
     core.saveState('path', inputs.path);
     core.saveState('cacheHit', inputs.cacheHit ? 'true' : 'false');
     core.saveState('lookupOnly', inputs.lookupOnly ? 'true' : 'false');
+    core.saveState('mode', inputs.mode);
 
     const sizeMsg = sizeBytes === null ? 'n/a (non-Linux)' : `${sizeBytes} B`;
     core.info(`cache-metrics: restored size = ${sizeMsg}, metrics written to ${file}`);

--- a/src/cache-metrics-post.ts
+++ b/src/cache-metrics-post.ts
@@ -17,11 +17,14 @@ export async function run(): Promise<void> {
     const pathInput = core.getState('path');
     const cacheHit = core.getState('cacheHit') === 'true';
     const lookupOnly = core.getState('lookupOnly') === 'true';
+    const mode = core.getState('mode');
 
     // Size measurement requires GNU `du -sb` (Linux only); null on other platforms.
     const sizeBytes = process.platform === 'linux' ? measureCacheBytes(pathInput) : null;
-    // The cache action skips save when it found an exact-match hit, or when in lookup-only mode.
-    const saved = !lookupOnly && !cacheHit;
+    // The cache action skips save when it found an exact-match hit, when in lookup-only mode, or when the
+    // S3 decision mode picked a save-incapable step (`restore-only`/`lookup`).
+    const saveIncapable = mode === 'restore-only' || mode === 'lookup';
+    const saved = !saveIncapable && !lookupOnly && !cacheHit;
 
     const prior = readMetricsFile(metricsFile);
     const record: CacheMetricsRecord = {

--- a/src/cache-metrics.ts
+++ b/src/cache-metrics.ts
@@ -12,6 +12,7 @@ export interface CacheMetricsInputs {
   lookupOnly: boolean;
   stepId: string;
   metricsDir: string;
+  mode: string;
 }
 
 export interface CacheMetricsRecord {
@@ -33,8 +34,8 @@ export interface CacheMetricsRecord {
    */
   size_bytes_at_end: number | null;
   /**
-   * Whether the cache action actually persists the cache at job end. False when `cache_hit` was true (exact match: cache action skips save)
-   * or when lookup-only` was set.
+   * Whether the cache action actually persists the cache at job end. False when `cache_hit` was true (exact match: cache action skips save),
+   * when `lookup-only` was set, or when the S3 decision mode was `restore-only`/`lookup` (a save-incapable step ran).
    */
   saved: boolean | null;
   timestamp_restored: string | null;
@@ -141,5 +142,6 @@ export function readInputs(): CacheMetricsInputs {
     // via the CI_METRICS_DIR env var. Default keeps the action usable on any
     // runner without that env preset.
     metricsDir: process.env.CI_METRICS_DIR || DEFAULT_METRICS_DIR,
+    mode: core.getInput('mode'),
   };
 }


### PR DESCRIPTION
## BUILD-11220 — Skip redundant S3 cache save of unchanged default-branch content

> **DRAFT.** This is an outside contribution. The change is intentionally **YAML + Bash only** (no `src/`/`dist/`/TypeScript
> changes). Please review the explicit maintainer-verification checklist at the bottom before merging.

### Root cause

On the S3 path, `scripts/prepare-keys.sh` computes a branch-scoped save key `branch-key = <branch>/<key>` and a
`branch-restore-keys` list whose **first entry is the fallback-exact key** `refs/heads/<default-branch>/<key>` (same `<key>` hash).

The single `Cache on S3` step used the combined `runs-on/cache` action, which restores in `main` and **saves in `post`
whenever the primary key was not an exact hit**. On a PR/feature branch:

1. `branch-key` misses (no branch-scoped entry yet),
2. content is restored from the fallback-exact key (byte-identical to the default-branch cache),
3. the combined action's post step then **re-uploads that identical content under `branch-key`** — on every run.

Branch-prefixing is intentional (permission isolation), so the fix is to **skip the save when the restored content came from
the fallback-exact key** (it is already in S3 as the default-branch entry).

### Design — probe to decide to restore-only/combined (S3 path only)

This keeps the existing combined `runs-on/cache` step for the genuine-miss case (so its post-save is preserved verbatim) and
only diverts the "restored unchanged from default branch" case to a save-less restore.

1. **`scripts/prepare-keys.sh`** also emits `fallback-exact-key` (reusing the existing `FALLBACK_EXACT_KEY` variable; empty when
   there is no fallback).
2. **Probe** (`s3-probe`): `runs-on/cache/restore` pinned to the **same SHA** (`/restore` path), `lookup-only: true`,
   `key: branch-key`, `restore-keys: branch-restore-keys`, with the same AWS-cred `env:` block the old step used. Determines what
   *would* match without downloading.
3. **Decide** (`s3-decide`, bash) outputs `mode`:
   - `lookup` — `inputs.lookup-only == 'true'`
   - `restore-only` — probe `cache-hit == 'true'` (branch already has exact content)
   - `restore-only` — probe `cache-matched-key` non-empty **and equal to** `fallback-exact-key` (content == default branch, skip
     duplicate save) — **the BUILD-11220 fix**
   - `combined` — otherwise (genuine miss, or a non-fallback partial match that legitimately needs saving under the branch key)
4. **Restore-only** (`s3-restore`): `runs-on/cache/restore` (same SHA), runs only when `mode == 'restore-only'`. Restores the
   content, no save. Enforces `fail-on-cache-miss` (the probe already proved a match exists).
5. **Combined** (`s3-cache`): the **existing** combined `runs-on/cache` step, unchanged except its `if:` now also requires
   `mode == 'combined'`. Its post step still saves the final path state under `branch-key`.

#### Ripples fixed

- **Aggregate cache outputs**: S3 `cache-hit`/`cache-matched-key` now coalesce `s3-cache` then `s3-restore` then `s3-probe` (so
  `restore-only` and `lookup` modes still surface outputs; the probe runs in every S3 mode, so a value is always present).
- **Import GitHub cache (migration fallback)** and **Enforce fail-on-cache-miss**: both `if:` blocks now also require
  `mode == 'combined'`, so they only run on a genuine miss (in `restore-only` we already found content in S3; guarding also avoids
  a false miss-error when `s3-cache`/`github-import` were skipped).
- `credential-guard`, `cache-metrics`, `symlink-keeper` are unchanged — they run for `backend == 's3'` / read the aggregated
  outputs.

All three new `runs-on/cache/restore` uses are pinned to the existing SHA `88d90644011a3a9957fd141a106f5a94f9794203` with the
`/restore` path.

### Producer-safety argument

Producer jobs (e.g. `build` / `cache_dependencies`) use sha-based keys like `jar-${sha}-${buildnum}` that **never** match the
default branch's fallback-exact key, so they always take `mode = combined` and their post-save is preserved unchanged. Only
**consumer** jobs that restored byte-identical content from the default-branch fallback take `restore-only` and skip the redundant
upload. Verified locally that an empty `fallback-exact-key` (e.g. running on the default branch itself, or with no fallback) can
never trigger `restore-only` — the decide step requires both the matched-key and the fallback-exact-key to be non-empty before
comparing.

### Accepted caveat

A feature-branch job that restores from the fallback-exact key and then **adds** content will not persist a branch-scoped copy
this run (it re-restores from the fallback next run instead). This is acceptable — it is exactly the duplication BUILD-11220 wants
gone. Jobs that genuinely produce new content have a different `key` (sha-based), so they fall into `combined` and do save.

### Local validation

- `action.yml` parses as YAML; `prepare-keys.sh` passes `bash -n`.
- `prepare-keys.sh` emits `fallback-exact-key=refs/heads/<branch>/<key>` when a fallback applies and an **empty** value when not.
- The `s3-decide` logic was exercised across all six branches (lookup-only / branch-exact-hit / fallback-exact-match /
  genuine-miss / non-fallback-partial-match / partial-match-no-fallback) and produced the correct mode each time.
- No changes under `src/` or `dist/`. No TypeScript rebuild needed.
- `actionlint` only lints workflow files, not standalone composite `action.yml`, so it was not run against this file (the repo's
  pre-commit `actionlint` hook targets `.github/workflows/**`). YAML validity confirmed separately.

### Maintainer must verify

- [ ] **lookup-only reports `cache-matched-key` for restore-key (partial) matches on the pinned SHA.** The whole fix depends on the
      probe surfacing the fallback-exact key as `cache-matched-key`. I verified this against upstream `runs-on/cache`
      `src/restoreImpl.ts` at the pinned SHA: `CacheMatchedKey` state and the `CacheHit` output are both set **before** the
      `lookupOnly` branch (which only changes log wording). Please confirm against the real S3 backend, since the S3 restore path
      uses a custom `restoreCache` — confirm it returns the matched restore-key under `lookupOnly` for S3 too.
- [ ] **Probe cost.** The probe adds one extra lookup-only round-trip per S3 cache step. Confirm this is acceptable (no download;
      should be a metadata-only operation against S3).
- [ ] **lookup-only + migration interaction.** Following the design, the GitHub-import fallback now requires `mode == 'combined'`,
      so when a caller sets `lookup-only: true` *and* migration mode is enabled, the action no longer does a lookup-only probe of
      the GitHub cache. If that combination matters, the import step's `if:` should be relaxed to also fire in `lookup` mode.
- [ ] **Aggregate-outputs coalescing** preserves prior `cache-hit`/`cache-matched-key`/`restore-key-hit` semantics in all modes
      (lookup / restore-only / combined), including the `cache-metrics` JSON record's `saved` field.
- [ ] Consider adding a regression job to `.github/workflows/test-action.yml` (the repo's convention) asserting that a
      consumer-with-fallback-exact restore does **not** re-save under the branch key, while a producer (sha-based key) still does.

### Test change (true-positive CI failure fixed by this PR)

`.github/workflows/test-cache-migration-gh2s3.yml` Scenario 4 (`test-s3-hit-skips-github-import`, "S3 hit → no GitHub import")
asserted `steps.cache.outputs.cache-hit == 'true'`. That only passed because the **old** action's duplicate save created an exact
branch-key entry: the `provision-s3-cache` job ran the action on the PR branch, matched the existing
`refs/heads/master/test-migration-s3hit` fallback in the shared **dev** bucket, and post-saved a `<branch>/test-migration-s3hit`
copy. This PR correctly **skips** that duplicate save, so the content is now served from the master fallback key — a fallback
restore, so `cache-hit=false` (and `cache-matched-key` = the master fallback key). The content is still correct and GitHub import
is still skipped; only the `cache-hit == true` proxy was wrong (and it was implicitly dependent on shared dev-bucket state).

The verify step now asserts an **S3 match regardless of exact-vs-fallback** plus the **correct content** — together these prove S3
served the data and GitHub import did NOT override it:

```diff
-          [[ "${{ steps.cache.outputs.cache-hit }}" == "true" ]] || { echo "ERROR: expected S3 hit"; exit 1; }
+          [[ -n "${{ steps.cache.outputs.cache-matched-key }}" ]] || { echo "ERROR: expected an S3 cache match"; exit 1; }
           [[ "$(cat ~/.cache/test-migration/test-file.txt)" == "s3-content" ]] || { echo "ERROR: ... GitHub import may have overridden S3"; exit 1; }
```

**Audit of the other scenarios** (only Scenario 4 had the genuine duplicate-save dependency — confirmed, nothing else changed):

- Scenario 1 (`test-s3-import-enabled`) and Scenario 5 (`test-auto-public-import-enabled`) assert `cache-hit == 'true'` + `github-content`,
  but that hit comes from the **exact GitHub-import** restore on key `test-migration-gh` (no S3 entry exists for that key). Both
  `rm -rf` the path before their post-save, so they never create a `refs/heads/master/test-migration-gh` S3 fallback that my probe
  could later match — they always take `mode == 'combined'` and import runs as before. Not affected.
- Scenarios 2 & 3 (`import-disabled`) assert `cache-hit != 'true'` + no file; still true. Not affected.
- `check-cache-migration.yml` is a `workflow_dispatch`-only list/compare reporting tool — it never invokes the action's restore
  path or asserts `cache-hit`. Not affected.

### Files changed

- `scripts/prepare-keys.sh` — emit `fallback-exact-key` output.
- `action.yml` — probe / decide / restore-only steps; combined step gated on `mode == 'combined'`; import + enforce + aggregate
  ripples.
- `README.md` — document the "no redundant save of default-branch content" behavior and its caveat.
- `.github/workflows/test-cache-migration-gh2s3.yml` — Scenario 4 assertion updated to match the non-duplicating behavior (see the
  Test change section above).

Refs BUILD-11220.

